### PR TITLE
Work in progress on tests for verifty_instr function

### DIFF
--- a/crates/move-bytecode-verifier/src/lib.rs
+++ b/crates/move-bytecode-verifier/src/lib.rs
@@ -45,3 +45,6 @@ mod reference_safety;
 mod regression_tests;
 mod stack_usage_verifier;
 mod type_safety;
+
+#[cfg(test)]
+mod type_safety_tests;

--- a/crates/move-bytecode-verifier/src/type_safety_tests/mod.rs
+++ b/crates/move-bytecode-verifier/src/type_safety_tests/mod.rs
@@ -108,3 +108,34 @@ fn test_br_false_no_arg() {
     let _result = type_safety::verify(&module, &fun_context, &mut DummyMeter);
 }
 
+
+#[test]
+fn test_abort_correct_type() {
+    let code = vec![Bytecode::LdU64(0), Bytecode::Abort];
+    let module = make_module(code);
+    let fun_context = get_fun_context(&module);
+    let result = type_safety::verify(&module, &fun_context, &mut DummyMeter);
+    assert!(result.is_ok());
+}
+
+
+#[test]
+fn test_abort_wrong_type() {
+    let code = vec![Bytecode::LdU32(0), Bytecode::Abort];
+    let module = make_module(code);
+    let fun_context = get_fun_context(&module);
+    let result = type_safety::verify(&module, &fun_context, &mut DummyMeter);
+    assert_eq!(
+        result.unwrap_err().major_status(),
+        StatusCode::ABORT_TYPE_MISMATCH_ERROR
+    );
+}
+
+#[test]
+#[should_panic]
+fn test_abort_no_arg() {
+    let code = vec![Bytecode::Abort];
+    let module = make_module(code);
+    let fun_context = get_fun_context(&module);
+    let _result = type_safety::verify(&module, &fun_context, &mut DummyMeter);
+}

--- a/crates/move-bytecode-verifier/src/type_safety_tests/mod.rs
+++ b/crates/move-bytecode-verifier/src/type_safety_tests/mod.rs
@@ -558,3 +558,19 @@ fn test_comparison_too_few_args() {
         let _result = type_safety::verify(&module, &fun_context, &mut DummyMeter);
     }
 }
+
+
+// these operation does not produce errors in verify_instr()
+#[test]
+fn test_branch_nop_ok() {
+    for instr in vec![
+        Bytecode::Branch(0),
+        Bytecode::Nop,
+    ] {
+        let code = vec![instr];
+        let module = make_module(code);
+        let fun_context = get_fun_context(&module);
+        let result = type_safety::verify(&module, &fun_context, &mut DummyMeter);
+        assert!(result.is_ok());
+    }
+}

--- a/crates/move-bytecode-verifier/src/type_safety_tests/mod.rs
+++ b/crates/move-bytecode-verifier/src/type_safety_tests/mod.rs
@@ -47,7 +47,7 @@ fn make_module_with_ret(code: Vec<Bytecode>, return_: SignatureToken) -> Compile
     let mut module = empty_module();
     module.function_handles.push(fun_handle);
     module.function_defs.push(fun_def);
-    module.signatures = vec![Signature(vec![]), Signature(vec![return_])];
+    module.signatures = vec![Signature(vec![]), Signature(vec![return_]), Signature(vec![])];
 
     module
 }
@@ -93,8 +93,8 @@ fn add_function_with_parameters(module: &mut CompiledModule, parameters: Signatu
     let fun_handle = FunctionHandle {
         module: ModuleHandleIndex(0),
         name: IdentifierIndex(0),
-        parameters: SignatureIndex(2),
-        return_: SignatureIndex(3),
+        parameters: SignatureIndex(3),
+        return_: SignatureIndex(4),
         type_parameters: vec![],
     };
 
@@ -117,14 +117,14 @@ fn add_generic_function_with_parameters(
     let fun_handle = FunctionHandle {
         module: ModuleHandleIndex(0),
         name: IdentifierIndex(0),
-        parameters: SignatureIndex(3),
-        return_: SignatureIndex(4),
+        parameters: SignatureIndex(4),
+        return_: SignatureIndex(5),
         type_parameters: vec![AbilitySet::PRIMITIVES],
     };
 
     let fun_inst = FunctionInstantiation {
         handle: FunctionHandleIndex(1),
-        type_parameters: SignatureIndex(2),
+        type_parameters: SignatureIndex(3),
     };
 
     module.signatures.push(Signature(vec![type_parameter]));
@@ -246,7 +246,7 @@ fn add_simple_struct_generic_with_abilities(
         .struct_def_instantiations
         .push(StructDefInstantiation {
             def: StructDefinitionIndex(0),
-            type_parameters: SignatureIndex(2),
+            type_parameters: SignatureIndex(3),
         });
 
     module.signatures.push(Signature(vec![type_parameter]));

--- a/crates/move-bytecode-verifier/src/type_safety_tests/mod.rs
+++ b/crates/move-bytecode-verifier/src/type_safety_tests/mod.rs
@@ -46,8 +46,9 @@ fn get_fun_context(module: &CompiledModule) -> FunctionContext {
     )
 }
 
+
 #[test]
-fn test_br_true_bool() {
+fn test_br_true_correct_type() {
     let code = vec![Bytecode::LdTrue, Bytecode::BrTrue(0)];
     let module = make_module(code);
     let fun_context = get_fun_context(&module);
@@ -56,7 +57,7 @@ fn test_br_true_bool() {
 }
 
 #[test]
-fn test_br_true_u32() {
+fn test_br_true_wrong_type() {
     let code = vec![Bytecode::LdU32(0), Bytecode::BrTrue(0)];
     let module = make_module(code);
     let fun_context = get_fun_context(&module);
@@ -75,3 +76,35 @@ fn test_br_true_no_arg() {
     let fun_context = get_fun_context(&module);
     let _result = type_safety::verify(&module, &fun_context, &mut DummyMeter);
 }
+
+
+#[test]
+fn test_br_false_correct_type() {
+    let code = vec![Bytecode::LdTrue, Bytecode::BrFalse(0)];
+    let module = make_module(code);
+    let fun_context = get_fun_context(&module);
+    let result = type_safety::verify(&module, &fun_context, &mut DummyMeter);
+    assert!(result.is_ok());
+}
+
+#[test]
+fn test_br_false_wrong_type() {
+    let code = vec![Bytecode::LdU32(0), Bytecode::BrFalse(0)];
+    let module = make_module(code);
+    let fun_context = get_fun_context(&module);
+    let result = type_safety::verify(&module, &fun_context, &mut DummyMeter);
+    assert_eq!(
+        result.unwrap_err().major_status(),
+        StatusCode::BR_TYPE_MISMATCH_ERROR
+    );
+}
+
+#[test]
+#[should_panic]
+fn test_br_false_no_arg() {
+    let code = vec![Bytecode::BrFalse(0)];
+    let module = make_module(code);
+    let fun_context = get_fun_context(&module);
+    let _result = type_safety::verify(&module, &fun_context, &mut DummyMeter);
+}
+

--- a/crates/move-bytecode-verifier/src/type_safety_tests/mod.rs
+++ b/crates/move-bytecode-verifier/src/type_safety_tests/mod.rs
@@ -1028,3 +1028,43 @@ fn test_move_loc_ok() {
     let result = type_safety::verify(&module, &fun_context, &mut DummyMeter);
     assert!(result.is_ok());
 }
+
+
+#[test]
+fn test_freeze_ref_correct_type() {
+    let code = vec![Bytecode::MutBorrowLoc(0), Bytecode::FreezeRef];
+    let module = make_module_with_local(code, SignatureToken::U64);
+    let fun_context = get_fun_context(&module);
+    let result = type_safety::verify(&module, &fun_context, &mut DummyMeter);
+    assert!(result.is_ok());
+}
+
+#[test]
+fn test_freeze_ref_wrong_type() {
+    let code = vec![Bytecode::ImmBorrowLoc(0), Bytecode::FreezeRef];
+    let module = make_module_with_local(code, SignatureToken::U64);
+    let fun_context = get_fun_context(&module);
+    let result = type_safety::verify(&module, &fun_context, &mut DummyMeter);
+    assert_eq!(
+        result.unwrap_err().major_status(),
+        StatusCode::FREEZEREF_TYPE_MISMATCH_ERROR
+    );
+
+    let code = vec![Bytecode::LdTrue, Bytecode::FreezeRef];
+    let module = make_module_with_local(code, SignatureToken::U64);
+    let fun_context = get_fun_context(&module);
+    let result = type_safety::verify(&module, &fun_context, &mut DummyMeter);
+    assert_eq!(
+        result.unwrap_err().major_status(),
+        StatusCode::FREEZEREF_TYPE_MISMATCH_ERROR
+    );
+}
+
+#[test]
+#[should_panic]
+fn test_freeze_ref_no_arg() {
+    let code = vec![Bytecode::FreezeRef];
+    let module = make_module_with_local(code, SignatureToken::U64);
+    let fun_context = get_fun_context(&module);
+    let _result = type_safety::verify(&module, &fun_context, &mut DummyMeter);
+}

--- a/crates/move-bytecode-verifier/src/type_safety_tests/mod.rs
+++ b/crates/move-bytecode-verifier/src/type_safety_tests/mod.rs
@@ -2715,6 +2715,118 @@ fn test_move_to_deprecated_no_arg() {
 }
 
 #[test]
+fn test_move_to_generic_deprecated_correct_type() {
+    let code = vec![
+        Bytecode::ImmBorrowLoc(0),
+        Bytecode::LdU32(42),
+        Bytecode::PackGeneric(StructDefInstantiationIndex(0)),
+        Bytecode::MoveToGenericDeprecated(StructDefInstantiationIndex(0)),
+    ];
+    let mut module = make_module_with_local(code, SignatureToken::Signer);
+    add_simple_struct_generic_with_abilities(&mut module, AbilitySet::ALL, SignatureToken::U32);
+    let fun_context = get_fun_context(&module);
+    let result = type_safety::verify(&module, &fun_context, &mut DummyMeter);
+    assert!(result.is_ok());
+}
+
+#[test]
+fn test_move_to_generic_deprecated_mismatched_types() {
+    let code = vec![
+        Bytecode::ImmBorrowLoc(0),
+        Bytecode::LdU32(42),
+        Bytecode::MoveToGenericDeprecated(StructDefInstantiationIndex(0)),
+    ];
+    let mut module = make_module_with_local(code, SignatureToken::Signer);
+    add_simple_struct_generic_with_abilities(&mut module, AbilitySet::ALL, SignatureToken::U32);
+    let fun_context = get_fun_context(&module);
+    let result = type_safety::verify(&module, &fun_context, &mut DummyMeter);
+    assert_eq!(
+        result.unwrap_err().major_status(),
+        StatusCode::MOVETO_TYPE_MISMATCH_ERROR
+    );
+}
+
+#[test]
+fn test_move_to_generic_deprecated_wrong_type() {
+    let code = vec![
+        Bytecode::MutBorrowLoc(0),
+        Bytecode::LdU32(42),
+        Bytecode::PackGeneric(StructDefInstantiationIndex(0)),
+        Bytecode::MoveToGenericDeprecated(StructDefInstantiationIndex(0)),
+    ];
+    let mut module = make_module_with_local(code, SignatureToken::Signer);
+    add_simple_struct_generic_with_abilities(&mut module, AbilitySet::ALL, SignatureToken::U32);
+    let fun_context = get_fun_context(&module);
+    let result = type_safety::verify(&module, &fun_context, &mut DummyMeter);
+    assert_eq!(
+        result.unwrap_err().major_status(),
+        StatusCode::MOVETO_TYPE_MISMATCH_ERROR
+    );
+
+    let code = vec![
+        Bytecode::ImmBorrowLoc(0),
+        Bytecode::LdU32(42),
+        Bytecode::PackGeneric(StructDefInstantiationIndex(0)),
+        Bytecode::MoveToGenericDeprecated(StructDefInstantiationIndex(0)),
+    ];
+    let mut module = make_module_with_local(code, SignatureToken::U32);
+    add_simple_struct_generic_with_abilities(&mut module, AbilitySet::ALL, SignatureToken::U32);
+    let fun_context = get_fun_context(&module);
+    let result = type_safety::verify(&module, &fun_context, &mut DummyMeter);
+    assert_eq!(
+        result.unwrap_err().major_status(),
+        StatusCode::MOVETO_TYPE_MISMATCH_ERROR
+    );
+}
+
+#[test]
+fn test_move_to_generic_deprecated_no_key() {
+    let code = vec![
+        Bytecode::ImmBorrowLoc(0),
+        Bytecode::LdU32(42),
+        Bytecode::PackGeneric(StructDefInstantiationIndex(0)),
+        Bytecode::MoveToGenericDeprecated(StructDefInstantiationIndex(0)),
+    ];
+    let mut module = make_module_with_local(code, SignatureToken::Signer);
+    add_simple_struct_generic_with_abilities(
+        &mut module,
+        AbilitySet::PRIMITIVES,
+        SignatureToken::U32,
+    );
+    let fun_context = get_fun_context(&module);
+    let result = type_safety::verify(&module, &fun_context, &mut DummyMeter);
+    assert_eq!(
+        result.unwrap_err().major_status(),
+        StatusCode::MOVETO_WITHOUT_KEY_ABILITY
+    );
+}
+
+#[test]
+#[should_panic]
+fn test_move_to_generic_deprecated_too_few_args() {
+    let code = vec![
+        Bytecode::ImmBorrowLoc(0),
+        Bytecode::MoveToGenericDeprecated(StructDefInstantiationIndex(0)),
+    ];
+    let mut module = make_module_with_local(code, SignatureToken::Signer);
+    add_simple_struct_generic_with_abilities(&mut module, AbilitySet::ALL, SignatureToken::U32);
+    let fun_context = get_fun_context(&module);
+    let _result = type_safety::verify(&module, &fun_context, &mut DummyMeter);
+}
+
+#[test]
+#[should_panic]
+fn test_move_to_generic_deprecated_no_arg() {
+    let code = vec![Bytecode::MoveToGenericDeprecated(
+        StructDefInstantiationIndex(0),
+    )];
+    let mut module = make_module_with_local(code, SignatureToken::Signer);
+    add_simple_struct_generic_with_abilities(&mut module, AbilitySet::ALL, SignatureToken::U32);
+    let fun_context = get_fun_context(&module);
+    let _result = type_safety::verify(&module, &fun_context, &mut DummyMeter);
+}
+
+#[test]
 fn test_borrow_global_deprecated_correct_type() {
     for instr in vec![
         Bytecode::ImmBorrowGlobalDeprecated(StructDefinitionIndex(0)),

--- a/crates/move-bytecode-verifier/src/type_safety_tests/mod.rs
+++ b/crates/move-bytecode-verifier/src/type_safety_tests/mod.rs
@@ -54,11 +54,11 @@ fn test_br_true_false_correct_type() {
         Bytecode::BrFalse(0),
     ] {
         let code = vec![Bytecode::LdTrue, instr];
-    let module = make_module(code);
-    let fun_context = get_fun_context(&module);
-    let result = type_safety::verify(&module, &fun_context, &mut DummyMeter);
-    assert!(result.is_ok());
-}
+        let module = make_module(code);
+        let fun_context = get_fun_context(&module);
+        let result = type_safety::verify(&module, &fun_context, &mut DummyMeter);
+        assert!(result.is_ok());
+    }
 }
 
 #[test]
@@ -68,13 +68,13 @@ fn test_br_true_false_wrong_type() {
         Bytecode::BrFalse(0),
     ] {
         let code = vec![Bytecode::LdU32(0), instr];
-    let module = make_module(code);
-    let fun_context = get_fun_context(&module);
-    let result = type_safety::verify(&module, &fun_context, &mut DummyMeter);
-    assert_eq!(
-        result.unwrap_err().major_status(),
-        StatusCode::BR_TYPE_MISMATCH_ERROR
-    );
+        let module = make_module(code);
+        let fun_context = get_fun_context(&module);
+        let result = type_safety::verify(&module, &fun_context, &mut DummyMeter);
+        assert_eq!(
+            result.unwrap_err().major_status(),
+            StatusCode::BR_TYPE_MISMATCH_ERROR
+        );
     }
 }
 
@@ -86,9 +86,9 @@ fn test_br_true_false_no_arg() {
         Bytecode::BrFalse(0),
     ] {
         let code = vec![instr];
-    let module = make_module(code);
-    let fun_context = get_fun_context(&module);
-    let _result = type_safety::verify(&module, &fun_context, &mut DummyMeter);
+        let module = make_module(code);
+        let fun_context = get_fun_context(&module);
+        let _result = type_safety::verify(&module, &fun_context, &mut DummyMeter);
     }
 }
 
@@ -122,4 +122,62 @@ fn test_abort_no_arg() {
     let module = make_module(code);
     let fun_context = get_fun_context(&module);
     let _result = type_safety::verify(&module, &fun_context, &mut DummyMeter);
+}
+
+
+#[test]
+fn test_cast_correct_type() {
+    for instr in vec![
+        Bytecode::CastU8,
+        Bytecode::CastU16,
+        Bytecode::CastU32,
+        Bytecode::CastU64,
+        Bytecode::CastU128,
+        Bytecode::CastU256,
+    ] {
+        let code = vec![Bytecode::LdU64(0), instr];
+        let module = make_module(code);
+        let fun_context = get_fun_context(&module);
+        let result = type_safety::verify(&module, &fun_context, &mut DummyMeter);
+        assert!(result.is_ok());
+    }
+}
+
+#[test]
+fn test_cast_wrong_type() {
+    for instr in vec![
+        Bytecode::CastU8,
+        Bytecode::CastU16,
+        Bytecode::CastU32,
+        Bytecode::CastU64,
+        Bytecode::CastU128,
+        Bytecode::CastU256,
+    ] {
+        let code = vec![Bytecode::LdTrue, instr];
+        let module = make_module(code);
+        let fun_context = get_fun_context(&module);
+        let result = type_safety::verify(&module, &fun_context, &mut DummyMeter);
+        assert_eq!(
+            result.unwrap_err().major_status(),
+            StatusCode::INTEGER_OP_TYPE_MISMATCH_ERROR
+        );
+    }
+}
+
+#[test]
+#[should_panic]
+fn test_cast_no_arg() {
+    for instr in vec![
+        Bytecode::CastU8,
+        Bytecode::CastU16,
+        Bytecode::CastU32,
+        Bytecode::CastU64,
+        Bytecode::CastU128,
+        Bytecode::CastU256,
+    ] {
+        let code = vec![instr];
+        let module = make_module(code);
+        let fun_context = get_fun_context(&module);
+        let _result = type_safety::verify(&module, &fun_context, &mut DummyMeter);
+    }
 }

--- a/crates/move-bytecode-verifier/src/type_safety_tests/mod.rs
+++ b/crates/move-bytecode-verifier/src/type_safety_tests/mod.rs
@@ -1977,3 +1977,108 @@ fn test_vec_pop_back_no_arg() {
     let fun_context = get_fun_context(&module);
     let _result = type_safety::verify(&module, &fun_context, &mut DummyMeter);
 }
+
+#[test]
+fn test_vec_swap_correct_type() {
+    let code = vec![
+        Bytecode::MutBorrowLoc(0),
+        Bytecode::LdU64(2),
+        Bytecode::LdU64(3),
+        Bytecode::VecSwap(SignatureIndex(3)),
+    ];
+    let mut module = make_module_with_local(code, SignatureToken::Vector(Box::new(SignatureToken::U32)));
+    module.signatures.push(Signature(vec![SignatureToken::U32]));
+    let fun_context = get_fun_context(&module);
+    let result = type_safety::verify(&module, &fun_context, &mut DummyMeter);
+    assert!(result.is_ok());
+}
+
+#[test]
+fn test_vec_swap_type_mismatch() {
+    let code = vec![
+        Bytecode::MutBorrowLoc(0),
+        Bytecode::LdU64(2),
+        Bytecode::LdU64(3),
+        Bytecode::VecSwap(SignatureIndex(3)),
+    ];
+    let mut module = make_module_with_local(code, SignatureToken::Vector(Box::new(SignatureToken::U32)));
+    module.signatures.push(Signature(vec![SignatureToken::U64]));
+    let fun_context = get_fun_context(&module);
+    let result = type_safety::verify(&module, &fun_context, &mut DummyMeter);
+    assert_eq!(result.unwrap_err().major_status(), StatusCode::TYPE_MISMATCH);
+}
+
+#[test]
+fn test_vec_swap_wrong_type() {
+    let code = vec![
+        Bytecode::LdTrue,
+        Bytecode::LdU64(2),
+        Bytecode::LdU64(3),
+        Bytecode::VecSwap(SignatureIndex(3)),
+    ];
+    let mut module = make_module_with_local(code, SignatureToken::Vector(Box::new(SignatureToken::U32)));
+    module.signatures.push(Signature(vec![SignatureToken::U32]));
+    let fun_context = get_fun_context(&module);
+    let result = type_safety::verify(&module, &fun_context, &mut DummyMeter);
+    assert_eq!(result.unwrap_err().major_status(), StatusCode::TYPE_MISMATCH);
+
+    let code = vec![
+        Bytecode::ImmBorrowLoc(0),
+        Bytecode::LdU64(2),
+        Bytecode::LdU64(3),
+        Bytecode::VecSwap(SignatureIndex(3)),
+    ];
+    let mut module = make_module_with_local(code, SignatureToken::Vector(Box::new(SignatureToken::U32)));
+    module.signatures.push(Signature(vec![SignatureToken::U32]));
+    let fun_context = get_fun_context(&module);
+    let result = type_safety::verify(&module, &fun_context, &mut DummyMeter);
+    assert_eq!(result.unwrap_err().major_status(), StatusCode::TYPE_MISMATCH);
+
+    let code = vec![
+        Bytecode::MutBorrowLoc(0),
+        Bytecode::LdU32(2),
+        Bytecode::LdU64(3),
+        Bytecode::VecSwap(SignatureIndex(3)),
+    ];
+    let mut module = make_module_with_local(code, SignatureToken::Vector(Box::new(SignatureToken::U32)));
+    module.signatures.push(Signature(vec![SignatureToken::U32]));
+    let fun_context = get_fun_context(&module);
+    let result = type_safety::verify(&module, &fun_context, &mut DummyMeter);
+    assert_eq!(result.unwrap_err().major_status(), StatusCode::TYPE_MISMATCH);
+
+    let code = vec![
+        Bytecode::MutBorrowLoc(0),
+        Bytecode::LdU64(2),
+        Bytecode::LdU32(3),
+        Bytecode::VecSwap(SignatureIndex(3)),
+    ];
+    let mut module = make_module_with_local(code, SignatureToken::Vector(Box::new(SignatureToken::U32)));
+    module.signatures.push(Signature(vec![SignatureToken::U32]));
+    let fun_context = get_fun_context(&module);
+    let result = type_safety::verify(&module, &fun_context, &mut DummyMeter);
+    assert_eq!(result.unwrap_err().major_status(), StatusCode::TYPE_MISMATCH);
+}
+
+#[test]
+#[should_panic]
+fn test_vec_swap_too_few_args() {
+    let code = vec![
+        Bytecode::MutBorrowLoc(0),
+        Bytecode::LdU64(2),
+        Bytecode::VecSwap(SignatureIndex(3)),
+    ];
+    let mut module = make_module_with_local(code, SignatureToken::Vector(Box::new(SignatureToken::U32)));
+    module.signatures.push(Signature(vec![SignatureToken::U32]));
+    let fun_context = get_fun_context(&module);
+    let _result = type_safety::verify(&module, &fun_context, &mut DummyMeter);
+}
+
+#[test]
+#[should_panic]
+fn test_vec_swap_no_arg() {
+    let code = vec![Bytecode::VecSwap(SignatureIndex(3))];
+    let mut module = make_module_with_local(code, SignatureToken::Vector(Box::new(SignatureToken::U32)));
+    module.signatures.push(Signature(vec![SignatureToken::U32]));
+    let fun_context = get_fun_context(&module);
+    let _result = type_safety::verify(&module, &fun_context, &mut DummyMeter);
+}

--- a/crates/move-bytecode-verifier/src/type_safety_tests/mod.rs
+++ b/crates/move-bytecode-verifier/src/type_safety_tests/mod.rs
@@ -73,7 +73,11 @@ fn make_module_with_local(code: Vec<Bytecode>, signature: SignatureToken) -> Com
     let mut module = empty_module();
     module.function_handles.push(fun_handle);
     module.function_defs.push(fun_def);
-    module.signatures = vec![Signature(vec![]), Signature(vec![SignatureToken::U32]), Signature(vec![signature])];
+    module.signatures = vec![
+        Signature(vec![]),
+        Signature(vec![SignatureToken::U32]),
+        Signature(vec![signature]),
+    ];
 
     module
 }
@@ -1553,7 +1557,8 @@ fn test_vec_len_correct_type() {
         Bytecode::ImmBorrowLoc(0),
         Bytecode::VecLen(SignatureIndex(3)),
     ];
-    let mut module = make_module_with_local(code, SignatureToken::Vector(Box::new(SignatureToken::U32)));
+    let mut module =
+        make_module_with_local(code, SignatureToken::Vector(Box::new(SignatureToken::U32)));
     module.signatures.push(Signature(vec![SignatureToken::U32]));
     let fun_context = get_fun_context(&module);
     let result = type_safety::verify(&module, &fun_context, &mut DummyMeter);
@@ -1566,7 +1571,8 @@ fn test_vec_len_type_mismatch() {
         Bytecode::ImmBorrowLoc(0),
         Bytecode::VecLen(SignatureIndex(3)),
     ];
-    let mut module = make_module_with_local(code, SignatureToken::Vector(Box::new(SignatureToken::U32)));
+    let mut module =
+        make_module_with_local(code, SignatureToken::Vector(Box::new(SignatureToken::U32)));
     module.signatures.push(Signature(vec![SignatureToken::U64]));
     let fun_context = get_fun_context(&module);
     let result = type_safety::verify(&module, &fun_context, &mut DummyMeter);
@@ -1578,11 +1584,9 @@ fn test_vec_len_type_mismatch() {
 
 #[test]
 fn test_vec_len_wrong_type() {
-    let code = vec![
-        Bytecode::LdU32(42),
-        Bytecode::VecLen(SignatureIndex(3)),
-    ];
-    let mut module = make_module_with_local(code, SignatureToken::Vector(Box::new(SignatureToken::U32)));
+    let code = vec![Bytecode::LdU32(42), Bytecode::VecLen(SignatureIndex(3))];
+    let mut module =
+        make_module_with_local(code, SignatureToken::Vector(Box::new(SignatureToken::U32)));
     module.signatures.push(Signature(vec![SignatureToken::U32]));
     let fun_context = get_fun_context(&module);
     let result = type_safety::verify(&module, &fun_context, &mut DummyMeter);
@@ -1596,7 +1600,8 @@ fn test_vec_len_wrong_type() {
 #[should_panic]
 fn test_vec_len_no_arg() {
     let code = vec![Bytecode::VecLen(SignatureIndex(3))];
-    let mut module = make_module_with_local(code, SignatureToken::Vector(Box::new(SignatureToken::U32)));
+    let mut module =
+        make_module_with_local(code, SignatureToken::Vector(Box::new(SignatureToken::U32)));
     module.signatures.push(Signature(vec![SignatureToken::U32]));
     let fun_context = get_fun_context(&module);
     let _result = type_safety::verify(&module, &fun_context, &mut DummyMeter);
@@ -1609,7 +1614,8 @@ fn test_vec_imm_borrow_correct_type() {
         Bytecode::LdU64(2),
         Bytecode::VecImmBorrow(SignatureIndex(3)),
     ];
-    let mut module = make_module_with_local(code, SignatureToken::Vector(Box::new(SignatureToken::U32)));
+    let mut module =
+        make_module_with_local(code, SignatureToken::Vector(Box::new(SignatureToken::U32)));
     module.signatures.push(Signature(vec![SignatureToken::U32]));
     let fun_context = get_fun_context(&module);
     let result = type_safety::verify(&module, &fun_context, &mut DummyMeter);
@@ -1620,7 +1626,8 @@ fn test_vec_imm_borrow_correct_type() {
         Bytecode::LdU64(2),
         Bytecode::VecImmBorrow(SignatureIndex(3)),
     ];
-    let mut module = make_module_with_local(code, SignatureToken::Vector(Box::new(SignatureToken::U32)));
+    let mut module =
+        make_module_with_local(code, SignatureToken::Vector(Box::new(SignatureToken::U32)));
     module.signatures.push(Signature(vec![SignatureToken::U32]));
     let fun_context = get_fun_context(&module);
     let result = type_safety::verify(&module, &fun_context, &mut DummyMeter);
@@ -1634,7 +1641,8 @@ fn test_vec_imm_borrow_type_mismatch() {
         Bytecode::LdU64(2),
         Bytecode::VecImmBorrow(SignatureIndex(3)),
     ];
-    let mut module = make_module_with_local(code, SignatureToken::Vector(Box::new(SignatureToken::U32)));
+    let mut module =
+        make_module_with_local(code, SignatureToken::Vector(Box::new(SignatureToken::U32)));
     module.signatures.push(Signature(vec![SignatureToken::U64]));
     let fun_context = get_fun_context(&module);
     let result = type_safety::verify(&module, &fun_context, &mut DummyMeter);
@@ -1651,7 +1659,8 @@ fn test_vec_imm_borrow_wrong_type() {
         Bytecode::LdU64(2),
         Bytecode::VecImmBorrow(SignatureIndex(3)),
     ];
-    let mut module = make_module_with_local(code, SignatureToken::Vector(Box::new(SignatureToken::U32)));
+    let mut module =
+        make_module_with_local(code, SignatureToken::Vector(Box::new(SignatureToken::U32)));
     module.signatures.push(Signature(vec![SignatureToken::U32]));
     let fun_context = get_fun_context(&module);
     let result = type_safety::verify(&module, &fun_context, &mut DummyMeter);
@@ -1665,7 +1674,8 @@ fn test_vec_imm_borrow_wrong_type() {
         Bytecode::LdU32(2),
         Bytecode::VecImmBorrow(SignatureIndex(3)),
     ];
-    let mut module = make_module_with_local(code, SignatureToken::Vector(Box::new(SignatureToken::U32)));
+    let mut module =
+        make_module_with_local(code, SignatureToken::Vector(Box::new(SignatureToken::U32)));
     module.signatures.push(Signature(vec![SignatureToken::U32]));
     let fun_context = get_fun_context(&module);
     let result = type_safety::verify(&module, &fun_context, &mut DummyMeter);
@@ -1682,7 +1692,8 @@ fn test_vec_imm_borrow_too_few_args() {
         Bytecode::ImmBorrowLoc(0),
         Bytecode::VecImmBorrow(SignatureIndex(3)),
     ];
-    let mut module = make_module_with_local(code, SignatureToken::Vector(Box::new(SignatureToken::U32)));
+    let mut module =
+        make_module_with_local(code, SignatureToken::Vector(Box::new(SignatureToken::U32)));
     module.signatures.push(Signature(vec![SignatureToken::U32]));
     let fun_context = get_fun_context(&module);
     let _result = type_safety::verify(&module, &fun_context, &mut DummyMeter);
@@ -1692,7 +1703,8 @@ fn test_vec_imm_borrow_too_few_args() {
 #[should_panic]
 fn test_vec_imm_borrow_no_arg() {
     let code = vec![Bytecode::VecImmBorrow(SignatureIndex(3))];
-    let mut module = make_module_with_local(code, SignatureToken::Vector(Box::new(SignatureToken::U32)));
+    let mut module =
+        make_module_with_local(code, SignatureToken::Vector(Box::new(SignatureToken::U32)));
     module.signatures.push(Signature(vec![SignatureToken::U32]));
     let fun_context = get_fun_context(&module);
     let _result = type_safety::verify(&module, &fun_context, &mut DummyMeter);
@@ -1705,7 +1717,8 @@ fn test_vec_mut_borrow_correct_type() {
         Bytecode::LdU64(2),
         Bytecode::VecMutBorrow(SignatureIndex(3)),
     ];
-    let mut module = make_module_with_local(code, SignatureToken::Vector(Box::new(SignatureToken::U32)));
+    let mut module =
+        make_module_with_local(code, SignatureToken::Vector(Box::new(SignatureToken::U32)));
     module.signatures.push(Signature(vec![SignatureToken::U32]));
     let fun_context = get_fun_context(&module);
     let result = type_safety::verify(&module, &fun_context, &mut DummyMeter);
@@ -1719,7 +1732,8 @@ fn test_vec_mut_borrow_type_mismatch() {
         Bytecode::LdU64(2),
         Bytecode::VecMutBorrow(SignatureIndex(3)),
     ];
-    let mut module = make_module_with_local(code, SignatureToken::Vector(Box::new(SignatureToken::U32)));
+    let mut module =
+        make_module_with_local(code, SignatureToken::Vector(Box::new(SignatureToken::U32)));
     module.signatures.push(Signature(vec![SignatureToken::U64]));
     let fun_context = get_fun_context(&module);
     let result = type_safety::verify(&module, &fun_context, &mut DummyMeter);
@@ -1736,7 +1750,8 @@ fn test_vec_mut_borrow_wrong_type() {
         Bytecode::LdU64(2),
         Bytecode::VecMutBorrow(SignatureIndex(3)),
     ];
-    let mut module = make_module_with_local(code, SignatureToken::Vector(Box::new(SignatureToken::U32)));
+    let mut module =
+        make_module_with_local(code, SignatureToken::Vector(Box::new(SignatureToken::U32)));
     module.signatures.push(Signature(vec![SignatureToken::U32]));
     let fun_context = get_fun_context(&module);
     let result = type_safety::verify(&module, &fun_context, &mut DummyMeter);
@@ -1750,7 +1765,8 @@ fn test_vec_mut_borrow_wrong_type() {
         Bytecode::LdU64(2),
         Bytecode::VecMutBorrow(SignatureIndex(3)),
     ];
-    let mut module = make_module_with_local(code, SignatureToken::Vector(Box::new(SignatureToken::U32)));
+    let mut module =
+        make_module_with_local(code, SignatureToken::Vector(Box::new(SignatureToken::U32)));
     module.signatures.push(Signature(vec![SignatureToken::U32]));
     let fun_context = get_fun_context(&module);
     let result = type_safety::verify(&module, &fun_context, &mut DummyMeter);
@@ -1764,7 +1780,8 @@ fn test_vec_mut_borrow_wrong_type() {
         Bytecode::LdU32(2),
         Bytecode::VecMutBorrow(SignatureIndex(3)),
     ];
-    let mut module = make_module_with_local(code, SignatureToken::Vector(Box::new(SignatureToken::U32)));
+    let mut module =
+        make_module_with_local(code, SignatureToken::Vector(Box::new(SignatureToken::U32)));
     module.signatures.push(Signature(vec![SignatureToken::U32]));
     let fun_context = get_fun_context(&module);
     let result = type_safety::verify(&module, &fun_context, &mut DummyMeter);
@@ -1781,7 +1798,8 @@ fn test_vec_mut_borrow_too_few_args() {
         Bytecode::MutBorrowLoc(0),
         Bytecode::VecMutBorrow(SignatureIndex(3)),
     ];
-    let mut module = make_module_with_local(code, SignatureToken::Vector(Box::new(SignatureToken::U32)));
+    let mut module =
+        make_module_with_local(code, SignatureToken::Vector(Box::new(SignatureToken::U32)));
     module.signatures.push(Signature(vec![SignatureToken::U32]));
     let fun_context = get_fun_context(&module);
     let _result = type_safety::verify(&module, &fun_context, &mut DummyMeter);
@@ -1791,7 +1809,8 @@ fn test_vec_mut_borrow_too_few_args() {
 #[should_panic]
 fn test_vec_mut_borrow_no_arg() {
     let code = vec![Bytecode::VecMutBorrow(SignatureIndex(3))];
-    let mut module = make_module_with_local(code, SignatureToken::Vector(Box::new(SignatureToken::U32)));
+    let mut module =
+        make_module_with_local(code, SignatureToken::Vector(Box::new(SignatureToken::U32)));
     module.signatures.push(Signature(vec![SignatureToken::U32]));
     let fun_context = get_fun_context(&module);
     let _result = type_safety::verify(&module, &fun_context, &mut DummyMeter);
@@ -1804,7 +1823,8 @@ fn test_vec_push_back_correct_type() {
         Bytecode::LdU32(42),
         Bytecode::VecPushBack(SignatureIndex(3)),
     ];
-    let mut module = make_module_with_local(code, SignatureToken::Vector(Box::new(SignatureToken::U32)));
+    let mut module =
+        make_module_with_local(code, SignatureToken::Vector(Box::new(SignatureToken::U32)));
     module.signatures.push(Signature(vec![SignatureToken::U32]));
     let fun_context = get_fun_context(&module);
     let result = type_safety::verify(&module, &fun_context, &mut DummyMeter);
@@ -1818,7 +1838,8 @@ fn test_vec_push_back_type_mismatch() {
         Bytecode::LdFalse,
         Bytecode::VecPushBack(SignatureIndex(3)),
     ];
-    let mut module = make_module_with_local(code, SignatureToken::Vector(Box::new(SignatureToken::U32)));
+    let mut module =
+        make_module_with_local(code, SignatureToken::Vector(Box::new(SignatureToken::U32)));
     module.signatures.push(Signature(vec![SignatureToken::U32]));
     let fun_context = get_fun_context(&module);
     let result = type_safety::verify(&module, &fun_context, &mut DummyMeter);
@@ -1832,7 +1853,8 @@ fn test_vec_push_back_type_mismatch() {
         Bytecode::LdU32(51),
         Bytecode::VecPushBack(SignatureIndex(3)),
     ];
-    let mut module = make_module_with_local(code, SignatureToken::Vector(Box::new(SignatureToken::U64)));
+    let mut module =
+        make_module_with_local(code, SignatureToken::Vector(Box::new(SignatureToken::U64)));
     module.signatures.push(Signature(vec![SignatureToken::U32]));
     let fun_context = get_fun_context(&module);
     let result = type_safety::verify(&module, &fun_context, &mut DummyMeter);
@@ -1846,7 +1868,8 @@ fn test_vec_push_back_type_mismatch() {
         Bytecode::LdU32(51),
         Bytecode::VecPushBack(SignatureIndex(3)),
     ];
-    let mut module = make_module_with_local(code, SignatureToken::Vector(Box::new(SignatureToken::U32)));
+    let mut module =
+        make_module_with_local(code, SignatureToken::Vector(Box::new(SignatureToken::U32)));
     module.signatures.push(Signature(vec![SignatureToken::U64]));
     let fun_context = get_fun_context(&module);
     let result = type_safety::verify(&module, &fun_context, &mut DummyMeter);
@@ -1863,7 +1886,8 @@ fn test_vec_push_back_wrong_type() {
         Bytecode::LdU32(42),
         Bytecode::VecPushBack(SignatureIndex(3)),
     ];
-    let mut module = make_module_with_local(code, SignatureToken::Vector(Box::new(SignatureToken::U32)));
+    let mut module =
+        make_module_with_local(code, SignatureToken::Vector(Box::new(SignatureToken::U32)));
     module.signatures.push(Signature(vec![SignatureToken::U32]));
     let fun_context = get_fun_context(&module);
     let result = type_safety::verify(&module, &fun_context, &mut DummyMeter);
@@ -1877,7 +1901,8 @@ fn test_vec_push_back_wrong_type() {
         Bytecode::LdU32(42),
         Bytecode::VecPushBack(SignatureIndex(3)),
     ];
-    let mut module = make_module_with_local(code, SignatureToken::Vector(Box::new(SignatureToken::U32)));
+    let mut module =
+        make_module_with_local(code, SignatureToken::Vector(Box::new(SignatureToken::U32)));
     module.signatures.push(Signature(vec![SignatureToken::U32]));
     let fun_context = get_fun_context(&module);
     let result = type_safety::verify(&module, &fun_context, &mut DummyMeter);
@@ -1894,7 +1919,8 @@ fn test_vec_push_back_too_few_args() {
         Bytecode::MutBorrowLoc(0),
         Bytecode::VecPushBack(SignatureIndex(3)),
     ];
-    let mut module = make_module_with_local(code, SignatureToken::Vector(Box::new(SignatureToken::U32)));
+    let mut module =
+        make_module_with_local(code, SignatureToken::Vector(Box::new(SignatureToken::U32)));
     module.signatures.push(Signature(vec![SignatureToken::U32]));
     let fun_context = get_fun_context(&module);
     let _result = type_safety::verify(&module, &fun_context, &mut DummyMeter);
@@ -1904,7 +1930,8 @@ fn test_vec_push_back_too_few_args() {
 #[should_panic]
 fn test_vec_push_back_no_arg() {
     let code = vec![Bytecode::VecPushBack(SignatureIndex(3))];
-    let mut module = make_module_with_local(code, SignatureToken::Vector(Box::new(SignatureToken::U32)));
+    let mut module =
+        make_module_with_local(code, SignatureToken::Vector(Box::new(SignatureToken::U32)));
     module.signatures.push(Signature(vec![SignatureToken::U32]));
     let fun_context = get_fun_context(&module);
     let _result = type_safety::verify(&module, &fun_context, &mut DummyMeter);
@@ -1916,7 +1943,8 @@ fn test_vec_pop_back_correct_type() {
         Bytecode::MutBorrowLoc(0),
         Bytecode::VecPopBack(SignatureIndex(3)),
     ];
-    let mut module = make_module_with_local(code, SignatureToken::Vector(Box::new(SignatureToken::U32)));
+    let mut module =
+        make_module_with_local(code, SignatureToken::Vector(Box::new(SignatureToken::U32)));
     module.signatures.push(Signature(vec![SignatureToken::U32]));
     let fun_context = get_fun_context(&module);
     let result = type_safety::verify(&module, &fun_context, &mut DummyMeter);
@@ -1929,7 +1957,8 @@ fn test_vec_pop_back_type_mismatch() {
         Bytecode::MutBorrowLoc(0),
         Bytecode::VecPopBack(SignatureIndex(3)),
     ];
-    let mut module = make_module_with_local(code, SignatureToken::Vector(Box::new(SignatureToken::U32)));
+    let mut module =
+        make_module_with_local(code, SignatureToken::Vector(Box::new(SignatureToken::U32)));
     module.signatures.push(Signature(vec![SignatureToken::U64]));
     let fun_context = get_fun_context(&module);
     let result = type_safety::verify(&module, &fun_context, &mut DummyMeter);
@@ -1941,11 +1970,9 @@ fn test_vec_pop_back_type_mismatch() {
 
 #[test]
 fn test_vec_pop_back_wrong_type() {
-    let code = vec![
-        Bytecode::LdTrue,
-        Bytecode::VecPopBack(SignatureIndex(3)),
-    ];
-    let mut module = make_module_with_local(code, SignatureToken::Vector(Box::new(SignatureToken::U32)));
+    let code = vec![Bytecode::LdTrue, Bytecode::VecPopBack(SignatureIndex(3))];
+    let mut module =
+        make_module_with_local(code, SignatureToken::Vector(Box::new(SignatureToken::U32)));
     module.signatures.push(Signature(vec![SignatureToken::U32]));
     let fun_context = get_fun_context(&module);
     let result = type_safety::verify(&module, &fun_context, &mut DummyMeter);
@@ -1958,7 +1985,8 @@ fn test_vec_pop_back_wrong_type() {
         Bytecode::ImmBorrowLoc(0),
         Bytecode::VecPopBack(SignatureIndex(3)),
     ];
-    let mut module = make_module_with_local(code, SignatureToken::Vector(Box::new(SignatureToken::U32)));
+    let mut module =
+        make_module_with_local(code, SignatureToken::Vector(Box::new(SignatureToken::U32)));
     module.signatures.push(Signature(vec![SignatureToken::U32]));
     let fun_context = get_fun_context(&module);
     let result = type_safety::verify(&module, &fun_context, &mut DummyMeter);
@@ -1972,7 +2000,8 @@ fn test_vec_pop_back_wrong_type() {
 #[should_panic]
 fn test_vec_pop_back_no_arg() {
     let code = vec![Bytecode::VecPopBack(SignatureIndex(3))];
-    let mut module = make_module_with_local(code, SignatureToken::Vector(Box::new(SignatureToken::U32)));
+    let mut module =
+        make_module_with_local(code, SignatureToken::Vector(Box::new(SignatureToken::U32)));
     module.signatures.push(Signature(vec![SignatureToken::U32]));
     let fun_context = get_fun_context(&module);
     let _result = type_safety::verify(&module, &fun_context, &mut DummyMeter);
@@ -1986,7 +2015,8 @@ fn test_vec_swap_correct_type() {
         Bytecode::LdU64(3),
         Bytecode::VecSwap(SignatureIndex(3)),
     ];
-    let mut module = make_module_with_local(code, SignatureToken::Vector(Box::new(SignatureToken::U32)));
+    let mut module =
+        make_module_with_local(code, SignatureToken::Vector(Box::new(SignatureToken::U32)));
     module.signatures.push(Signature(vec![SignatureToken::U32]));
     let fun_context = get_fun_context(&module);
     let result = type_safety::verify(&module, &fun_context, &mut DummyMeter);
@@ -2001,11 +2031,15 @@ fn test_vec_swap_type_mismatch() {
         Bytecode::LdU64(3),
         Bytecode::VecSwap(SignatureIndex(3)),
     ];
-    let mut module = make_module_with_local(code, SignatureToken::Vector(Box::new(SignatureToken::U32)));
+    let mut module =
+        make_module_with_local(code, SignatureToken::Vector(Box::new(SignatureToken::U32)));
     module.signatures.push(Signature(vec![SignatureToken::U64]));
     let fun_context = get_fun_context(&module);
     let result = type_safety::verify(&module, &fun_context, &mut DummyMeter);
-    assert_eq!(result.unwrap_err().major_status(), StatusCode::TYPE_MISMATCH);
+    assert_eq!(
+        result.unwrap_err().major_status(),
+        StatusCode::TYPE_MISMATCH
+    );
 }
 
 #[test]
@@ -2016,11 +2050,15 @@ fn test_vec_swap_wrong_type() {
         Bytecode::LdU64(3),
         Bytecode::VecSwap(SignatureIndex(3)),
     ];
-    let mut module = make_module_with_local(code, SignatureToken::Vector(Box::new(SignatureToken::U32)));
+    let mut module =
+        make_module_with_local(code, SignatureToken::Vector(Box::new(SignatureToken::U32)));
     module.signatures.push(Signature(vec![SignatureToken::U32]));
     let fun_context = get_fun_context(&module);
     let result = type_safety::verify(&module, &fun_context, &mut DummyMeter);
-    assert_eq!(result.unwrap_err().major_status(), StatusCode::TYPE_MISMATCH);
+    assert_eq!(
+        result.unwrap_err().major_status(),
+        StatusCode::TYPE_MISMATCH
+    );
 
     let code = vec![
         Bytecode::ImmBorrowLoc(0),
@@ -2028,11 +2066,15 @@ fn test_vec_swap_wrong_type() {
         Bytecode::LdU64(3),
         Bytecode::VecSwap(SignatureIndex(3)),
     ];
-    let mut module = make_module_with_local(code, SignatureToken::Vector(Box::new(SignatureToken::U32)));
+    let mut module =
+        make_module_with_local(code, SignatureToken::Vector(Box::new(SignatureToken::U32)));
     module.signatures.push(Signature(vec![SignatureToken::U32]));
     let fun_context = get_fun_context(&module);
     let result = type_safety::verify(&module, &fun_context, &mut DummyMeter);
-    assert_eq!(result.unwrap_err().major_status(), StatusCode::TYPE_MISMATCH);
+    assert_eq!(
+        result.unwrap_err().major_status(),
+        StatusCode::TYPE_MISMATCH
+    );
 
     let code = vec![
         Bytecode::MutBorrowLoc(0),
@@ -2040,11 +2082,15 @@ fn test_vec_swap_wrong_type() {
         Bytecode::LdU64(3),
         Bytecode::VecSwap(SignatureIndex(3)),
     ];
-    let mut module = make_module_with_local(code, SignatureToken::Vector(Box::new(SignatureToken::U32)));
+    let mut module =
+        make_module_with_local(code, SignatureToken::Vector(Box::new(SignatureToken::U32)));
     module.signatures.push(Signature(vec![SignatureToken::U32]));
     let fun_context = get_fun_context(&module);
     let result = type_safety::verify(&module, &fun_context, &mut DummyMeter);
-    assert_eq!(result.unwrap_err().major_status(), StatusCode::TYPE_MISMATCH);
+    assert_eq!(
+        result.unwrap_err().major_status(),
+        StatusCode::TYPE_MISMATCH
+    );
 
     let code = vec![
         Bytecode::MutBorrowLoc(0),
@@ -2052,11 +2098,15 @@ fn test_vec_swap_wrong_type() {
         Bytecode::LdU32(3),
         Bytecode::VecSwap(SignatureIndex(3)),
     ];
-    let mut module = make_module_with_local(code, SignatureToken::Vector(Box::new(SignatureToken::U32)));
+    let mut module =
+        make_module_with_local(code, SignatureToken::Vector(Box::new(SignatureToken::U32)));
     module.signatures.push(Signature(vec![SignatureToken::U32]));
     let fun_context = get_fun_context(&module);
     let result = type_safety::verify(&module, &fun_context, &mut DummyMeter);
-    assert_eq!(result.unwrap_err().major_status(), StatusCode::TYPE_MISMATCH);
+    assert_eq!(
+        result.unwrap_err().major_status(),
+        StatusCode::TYPE_MISMATCH
+    );
 }
 
 #[test]
@@ -2067,7 +2117,8 @@ fn test_vec_swap_too_few_args() {
         Bytecode::LdU64(2),
         Bytecode::VecSwap(SignatureIndex(3)),
     ];
-    let mut module = make_module_with_local(code, SignatureToken::Vector(Box::new(SignatureToken::U32)));
+    let mut module =
+        make_module_with_local(code, SignatureToken::Vector(Box::new(SignatureToken::U32)));
     module.signatures.push(Signature(vec![SignatureToken::U32]));
     let fun_context = get_fun_context(&module);
     let _result = type_safety::verify(&module, &fun_context, &mut DummyMeter);
@@ -2077,7 +2128,8 @@ fn test_vec_swap_too_few_args() {
 #[should_panic]
 fn test_vec_swap_no_arg() {
     let code = vec![Bytecode::VecSwap(SignatureIndex(3))];
-    let mut module = make_module_with_local(code, SignatureToken::Vector(Box::new(SignatureToken::U32)));
+    let mut module =
+        make_module_with_local(code, SignatureToken::Vector(Box::new(SignatureToken::U32)));
     module.signatures.push(Signature(vec![SignatureToken::U32]));
     let fun_context = get_fun_context(&module);
     let _result = type_safety::verify(&module, &fun_context, &mut DummyMeter);

--- a/crates/move-bytecode-verifier/src/type_safety_tests/mod.rs
+++ b/crates/move-bytecode-verifier/src/type_safety_tests/mod.rs
@@ -1697,3 +1697,102 @@ fn test_vec_imm_borrow_no_arg() {
     let fun_context = get_fun_context(&module);
     let _result = type_safety::verify(&module, &fun_context, &mut DummyMeter);
 }
+
+#[test]
+fn test_vec_mut_borrow_correct_type() {
+    let code = vec![
+        Bytecode::MutBorrowLoc(0),
+        Bytecode::LdU64(2),
+        Bytecode::VecMutBorrow(SignatureIndex(3)),
+    ];
+    let mut module = make_module_with_local(code, SignatureToken::Vector(Box::new(SignatureToken::U32)));
+    module.signatures.push(Signature(vec![SignatureToken::U32]));
+    let fun_context = get_fun_context(&module);
+    let result = type_safety::verify(&module, &fun_context, &mut DummyMeter);
+    assert!(result.is_ok());
+}
+
+#[test]
+fn test_vec_mut_borrow_type_mismatch() {
+    let code = vec![
+        Bytecode::MutBorrowLoc(0),
+        Bytecode::LdU64(2),
+        Bytecode::VecMutBorrow(SignatureIndex(3)),
+    ];
+    let mut module = make_module_with_local(code, SignatureToken::Vector(Box::new(SignatureToken::U32)));
+    module.signatures.push(Signature(vec![SignatureToken::U64]));
+    let fun_context = get_fun_context(&module);
+    let result = type_safety::verify(&module, &fun_context, &mut DummyMeter);
+    assert_eq!(
+        result.unwrap_err().major_status(),
+        StatusCode::TYPE_MISMATCH
+    );
+}
+
+#[test]
+fn test_vec_mut_borrow_wrong_type() {
+    let code = vec![
+        Bytecode::LdU32(42),
+        Bytecode::LdU64(2),
+        Bytecode::VecMutBorrow(SignatureIndex(3)),
+    ];
+    let mut module = make_module_with_local(code, SignatureToken::Vector(Box::new(SignatureToken::U32)));
+    module.signatures.push(Signature(vec![SignatureToken::U32]));
+    let fun_context = get_fun_context(&module);
+    let result = type_safety::verify(&module, &fun_context, &mut DummyMeter);
+    assert_eq!(
+        result.unwrap_err().major_status(),
+        StatusCode::TYPE_MISMATCH
+    );
+
+    let code = vec![
+        Bytecode::ImmBorrowLoc(0),
+        Bytecode::LdU64(2),
+        Bytecode::VecMutBorrow(SignatureIndex(3)),
+    ];
+    let mut module = make_module_with_local(code, SignatureToken::Vector(Box::new(SignatureToken::U32)));
+    module.signatures.push(Signature(vec![SignatureToken::U32]));
+    let fun_context = get_fun_context(&module);
+    let result = type_safety::verify(&module, &fun_context, &mut DummyMeter);
+    assert_eq!(
+        result.unwrap_err().major_status(),
+        StatusCode::TYPE_MISMATCH
+    );
+
+    let code = vec![
+        Bytecode::MutBorrowLoc(0),
+        Bytecode::LdU32(2),
+        Bytecode::VecMutBorrow(SignatureIndex(3)),
+    ];
+    let mut module = make_module_with_local(code, SignatureToken::Vector(Box::new(SignatureToken::U32)));
+    module.signatures.push(Signature(vec![SignatureToken::U32]));
+    let fun_context = get_fun_context(&module);
+    let result = type_safety::verify(&module, &fun_context, &mut DummyMeter);
+    assert_eq!(
+        result.unwrap_err().major_status(),
+        StatusCode::TYPE_MISMATCH
+    );
+}
+
+#[test]
+#[should_panic]
+fn test_vec_mut_borrow_too_few_args() {
+    let code = vec![
+        Bytecode::MutBorrowLoc(0),
+        Bytecode::VecMutBorrow(SignatureIndex(3)),
+    ];
+    let mut module = make_module_with_local(code, SignatureToken::Vector(Box::new(SignatureToken::U32)));
+    module.signatures.push(Signature(vec![SignatureToken::U32]));
+    let fun_context = get_fun_context(&module);
+    let _result = type_safety::verify(&module, &fun_context, &mut DummyMeter);
+}
+
+#[test]
+#[should_panic]
+fn test_vec_mut_borrow_no_arg() {
+    let code = vec![Bytecode::VecMutBorrow(SignatureIndex(3))];
+    let mut module = make_module_with_local(code, SignatureToken::Vector(Box::new(SignatureToken::U32)));
+    module.signatures.push(Signature(vec![SignatureToken::U32]));
+    let fun_context = get_fun_context(&module);
+    let _result = type_safety::verify(&module, &fun_context, &mut DummyMeter);
+}

--- a/crates/move-bytecode-verifier/src/type_safety_tests/mod.rs
+++ b/crates/move-bytecode-verifier/src/type_safety_tests/mod.rs
@@ -895,3 +895,35 @@ fn test_eq_neq_no_args() {
         let _result = type_safety::verify(&module, &fun_context, &mut DummyMeter);
     }
 }
+
+
+#[test]
+fn test_pop_ok() {
+    let code = vec![Bytecode::LdU32(42), Bytecode::Pop];
+    let module = make_module(code);
+    let fun_context = get_fun_context(&module);
+    let result = type_safety::verify(&module, &fun_context, &mut DummyMeter);
+    assert!(result.is_ok());
+}
+
+#[test]
+fn test_pop_no_drop() {
+    let code = vec![Bytecode::LdU32(42), Bytecode::Pack(StructDefinitionIndex(0)), Bytecode::Pop];
+    let mut module = make_module(code);
+    add_simple_struct_with_abilities(&mut module, AbilitySet::EMPTY);
+    let fun_context = get_fun_context(&module);
+    let result = type_safety::verify(&module, &fun_context, &mut DummyMeter);
+    assert_eq!(
+        result.unwrap_err().major_status(),
+        StatusCode::POP_WITHOUT_DROP_ABILITY
+    );
+}
+
+#[test]
+#[should_panic]
+fn test_pop_no_arg() {
+    let code = vec![Bytecode::Pop];
+    let module = make_module(code);
+    let fun_context = get_fun_context(&module);
+    let _result = type_safety::verify(&module, &fun_context, &mut DummyMeter);
+}

--- a/crates/move-bytecode-verifier/src/type_safety_tests/mod.rs
+++ b/crates/move-bytecode-verifier/src/type_safety_tests/mod.rs
@@ -2548,6 +2548,67 @@ fn test_move_from_deprecated_no_arg() {
 }
 
 #[test]
+fn test_move_from_generic_deprecated_correct_type() {
+    let code = vec![
+        Bytecode::CopyLoc(0),
+        Bytecode::MoveFromGenericDeprecated(StructDefInstantiationIndex(0)),
+    ];
+    let mut module = make_module_with_local(code, SignatureToken::Address);
+    add_simple_struct_generic_with_abilities(&mut module, AbilitySet::ALL, SignatureToken::U32);
+    let fun_context = get_fun_context(&module);
+    let result = type_safety::verify(&module, &fun_context, &mut DummyMeter);
+    assert!(result.is_ok());
+}
+
+#[test]
+fn test_move_from_generic_deprecated_wrong_type() {
+    let code = vec![
+        Bytecode::LdU64(42),
+        Bytecode::MoveFromGenericDeprecated(StructDefInstantiationIndex(0)),
+    ];
+    let mut module = make_module_with_local(code, SignatureToken::Address);
+    add_simple_struct_generic_with_abilities(&mut module, AbilitySet::ALL, SignatureToken::U32);
+    let fun_context = get_fun_context(&module);
+    let result = type_safety::verify(&module, &fun_context, &mut DummyMeter);
+    assert_eq!(
+        result.unwrap_err().major_status(),
+        StatusCode::MOVEFROM_TYPE_MISMATCH_ERROR
+    );
+}
+
+#[test]
+fn test_move_from_generic_deprecated_no_key() {
+    let code = vec![
+        Bytecode::CopyLoc(0),
+        Bytecode::MoveFromGenericDeprecated(StructDefInstantiationIndex(0)),
+    ];
+    let mut module = make_module_with_local(code, SignatureToken::Address);
+    add_simple_struct_generic_with_abilities(
+        &mut module,
+        AbilitySet::PRIMITIVES,
+        SignatureToken::U32,
+    );
+    let fun_context = get_fun_context(&module);
+    let result = type_safety::verify(&module, &fun_context, &mut DummyMeter);
+    assert_eq!(
+        result.unwrap_err().major_status(),
+        StatusCode::MOVEFROM_WITHOUT_KEY_ABILITY
+    );
+}
+
+#[test]
+#[should_panic]
+fn test_move_from_generic_deprecated_no_arg() {
+    let code = vec![Bytecode::MoveFromGenericDeprecated(
+        StructDefInstantiationIndex(0),
+    )];
+    let mut module = make_module_with_local(code, SignatureToken::Address);
+    add_simple_struct_generic_with_abilities(&mut module, AbilitySet::ALL, SignatureToken::U32);
+    let fun_context = get_fun_context(&module);
+    let _result = type_safety::verify(&module, &fun_context, &mut DummyMeter);
+}
+
+#[test]
 fn test_move_to_deprecated_correct_type() {
     let code = vec![
         Bytecode::ImmBorrowLoc(0),

--- a/crates/move-bytecode-verifier/src/type_safety_tests/mod.rs
+++ b/crates/move-bytecode-verifier/src/type_safety_tests/mod.rs
@@ -343,7 +343,22 @@ fn test_arithmetic_too_few_args() {
         let module = make_module(code);
         let fun_context = get_fun_context(&module);
         let _result = type_safety::verify(&module, &fun_context, &mut DummyMeter);
+    }
+}
 
+#[test]
+#[should_panic]
+fn test_arithmetic_no_args() {
+    for instr in vec![
+        Bytecode::Add,
+        Bytecode::Sub,
+        Bytecode::Mul,
+        Bytecode::Mod,
+        Bytecode::Div,
+        Bytecode::BitOr,
+        Bytecode::BitAnd,
+        Bytecode::Xor,
+    ] {
         let code = vec![instr.clone()];
         let module = make_module(code);
         let fun_context = get_fun_context(&module);
@@ -421,6 +436,16 @@ fn test_shl_shr_too_few_args() {
         let fun_context = get_fun_context(&module);
         let _result = type_safety::verify(&module, &fun_context, &mut DummyMeter);
 
+    }
+}
+
+#[test]
+#[should_panic]
+fn test_shl_shr_no_args() {
+    for instr in vec![
+        Bytecode::Shl,
+        Bytecode::Shr,
+    ] {
         let code = vec![instr.clone()];
         let module = make_module(code);
         let fun_context = get_fun_context(&module);
@@ -480,7 +505,16 @@ fn test_or_and_too_few_args() {
         let module = make_module(code);
         let fun_context = get_fun_context(&module);
         let _result = type_safety::verify(&module, &fun_context, &mut DummyMeter);
+    }
+}
 
+#[test]
+#[should_panic]
+fn test_or_and_no_args() {
+    for instr in vec![
+        Bytecode::Or,
+        Bytecode::And,
+    ] {
         let code = vec![instr.clone()];
         let module = make_module(code);
         let fun_context = get_fun_context(&module);
@@ -607,7 +641,18 @@ fn test_comparison_too_few_args() {
         let module = make_module(code);
         let fun_context = get_fun_context(&module);
         let _result = type_safety::verify(&module, &fun_context, &mut DummyMeter);
+    }
+}
 
+#[test]
+#[should_panic]
+fn test_comparison_no_args() {
+    for instr in vec![
+        Bytecode::Lt,
+        Bytecode::Gt,
+        Bytecode::Le,
+        Bytecode::Ge,
+    ] {
         let code = vec![instr.clone()];
         let module = make_module(code);
         let fun_context = get_fun_context(&module);
@@ -834,7 +879,16 @@ fn test_eq_neq_too_few_args() {
         let module = make_module(code);
         let fun_context = get_fun_context(&module);
         let _result = type_safety::verify(&module, &fun_context, &mut DummyMeter);
+    }
+}
 
+#[test]
+#[should_panic]
+fn test_eq_neq_no_args() {
+    for instr in vec![
+        Bytecode::Eq,
+        Bytecode::Neq,
+    ] {
         let code = vec![instr.clone()];
         let module = make_module(code);
         let fun_context = get_fun_context(&module);

--- a/crates/move-bytecode-verifier/src/type_safety_tests/mod.rs
+++ b/crates/move-bytecode-verifier/src/type_safety_tests/mod.rs
@@ -294,3 +294,80 @@ fn test_arithmetic_too_few_args() {
         let _result = type_safety::verify(&module, &fun_context, &mut DummyMeter);
     }
 }
+
+
+#[test]
+fn test_shl_shr_correct_types() {
+    for instr in vec![
+        Bytecode::Shl,
+        Bytecode::Shr,
+    ] {
+        for push_ty_instr in vec![
+            Bytecode::LdU8(42),
+            Bytecode::LdU16(257),
+            Bytecode::LdU32(89),
+            Bytecode::LdU64(94),
+            Bytecode::LdU128(Box::new(9999)),
+            Bytecode::LdU256(Box::new(U256::from(745_u32))),
+        ] {
+            let code = vec![push_ty_instr.clone(), Bytecode::LdU8(2), instr.clone()];
+            let module = make_module(code);
+            let fun_context = get_fun_context(&module);
+            let result = type_safety::verify(&module, &fun_context, &mut DummyMeter);
+            assert!(result.is_ok());
+        }
+    }
+}
+
+#[test]
+fn test_shl_shr_first_operand_wrong_type() {
+    for instr in vec![
+        Bytecode::Shl,
+        Bytecode::Shr,
+    ] {
+        let code = vec![Bytecode::LdTrue, Bytecode::LdU8(2), instr.clone()];
+        let module = make_module(code);
+        let fun_context = get_fun_context(&module);
+        let result = type_safety::verify(&module, &fun_context, &mut DummyMeter);
+        assert_eq!(
+            result.unwrap_err().major_status(),
+            StatusCode::INTEGER_OP_TYPE_MISMATCH_ERROR
+        );
+    }
+}
+
+#[test]
+fn test_shl_shr_second_operand_wrong_type() {
+    for instr in vec![
+        Bytecode::Shl,
+        Bytecode::Shr,
+    ] {
+        let code = vec![Bytecode::LdU32(42), Bytecode::LdU16(2), instr.clone()];
+        let module = make_module(code);
+        let fun_context = get_fun_context(&module);
+        let result = type_safety::verify(&module, &fun_context, &mut DummyMeter);
+        assert_eq!(
+            result.unwrap_err().major_status(),
+            StatusCode::INTEGER_OP_TYPE_MISMATCH_ERROR
+        );
+    }
+}
+
+#[test]
+#[should_panic]
+fn test_shl_shr_too_few_args() {
+    for instr in vec![
+        Bytecode::Shl,
+        Bytecode::Shr,
+    ] {
+        let code = vec![Bytecode::LdU16(42), instr.clone()];
+        let module = make_module(code);
+        let fun_context = get_fun_context(&module);
+        let _result = type_safety::verify(&module, &fun_context, &mut DummyMeter);
+
+        let code = vec![instr.clone()];
+        let module = make_module(code);
+        let fun_context = get_fun_context(&module);
+        let _result = type_safety::verify(&module, &fun_context, &mut DummyMeter);
+    }
+}

--- a/crates/move-bytecode-verifier/src/type_safety_tests/mod.rs
+++ b/crates/move-bytecode-verifier/src/type_safety_tests/mod.rs
@@ -1601,3 +1601,99 @@ fn test_vec_len_no_arg() {
     let fun_context = get_fun_context(&module);
     let _result = type_safety::verify(&module, &fun_context, &mut DummyMeter);
 }
+
+#[test]
+fn test_vec_imm_borrow_correct_type() {
+    let code = vec![
+        Bytecode::ImmBorrowLoc(0),
+        Bytecode::LdU64(2),
+        Bytecode::VecImmBorrow(SignatureIndex(3)),
+    ];
+    let mut module = make_module_with_local(code, SignatureToken::Vector(Box::new(SignatureToken::U32)));
+    module.signatures.push(Signature(vec![SignatureToken::U32]));
+    let fun_context = get_fun_context(&module);
+    let result = type_safety::verify(&module, &fun_context, &mut DummyMeter);
+    assert!(result.is_ok());
+
+    let code = vec![
+        Bytecode::MutBorrowLoc(0),
+        Bytecode::LdU64(2),
+        Bytecode::VecImmBorrow(SignatureIndex(3)),
+    ];
+    let mut module = make_module_with_local(code, SignatureToken::Vector(Box::new(SignatureToken::U32)));
+    module.signatures.push(Signature(vec![SignatureToken::U32]));
+    let fun_context = get_fun_context(&module);
+    let result = type_safety::verify(&module, &fun_context, &mut DummyMeter);
+    assert!(result.is_ok());
+}
+
+#[test]
+fn test_vec_imm_borrow_type_mismatch() {
+    let code = vec![
+        Bytecode::ImmBorrowLoc(0),
+        Bytecode::LdU64(2),
+        Bytecode::VecImmBorrow(SignatureIndex(3)),
+    ];
+    let mut module = make_module_with_local(code, SignatureToken::Vector(Box::new(SignatureToken::U32)));
+    module.signatures.push(Signature(vec![SignatureToken::U64]));
+    let fun_context = get_fun_context(&module);
+    let result = type_safety::verify(&module, &fun_context, &mut DummyMeter);
+    assert_eq!(
+        result.unwrap_err().major_status(),
+        StatusCode::TYPE_MISMATCH
+    );
+}
+
+#[test]
+fn test_vec_imm_borrow_wrong_type() {
+    let code = vec![
+        Bytecode::LdU32(42),
+        Bytecode::LdU64(2),
+        Bytecode::VecImmBorrow(SignatureIndex(3)),
+    ];
+    let mut module = make_module_with_local(code, SignatureToken::Vector(Box::new(SignatureToken::U32)));
+    module.signatures.push(Signature(vec![SignatureToken::U32]));
+    let fun_context = get_fun_context(&module);
+    let result = type_safety::verify(&module, &fun_context, &mut DummyMeter);
+    assert_eq!(
+        result.unwrap_err().major_status(),
+        StatusCode::TYPE_MISMATCH
+    );
+
+    let code = vec![
+        Bytecode::ImmBorrowLoc(0),
+        Bytecode::LdU32(2),
+        Bytecode::VecImmBorrow(SignatureIndex(3)),
+    ];
+    let mut module = make_module_with_local(code, SignatureToken::Vector(Box::new(SignatureToken::U32)));
+    module.signatures.push(Signature(vec![SignatureToken::U32]));
+    let fun_context = get_fun_context(&module);
+    let result = type_safety::verify(&module, &fun_context, &mut DummyMeter);
+    assert_eq!(
+        result.unwrap_err().major_status(),
+        StatusCode::TYPE_MISMATCH
+    );
+}
+
+#[test]
+#[should_panic]
+fn test_vec_imm_borrow_too_few_args() {
+    let code = vec![
+        Bytecode::ImmBorrowLoc(0),
+        Bytecode::VecImmBorrow(SignatureIndex(3)),
+    ];
+    let mut module = make_module_with_local(code, SignatureToken::Vector(Box::new(SignatureToken::U32)));
+    module.signatures.push(Signature(vec![SignatureToken::U32]));
+    let fun_context = get_fun_context(&module);
+    let _result = type_safety::verify(&module, &fun_context, &mut DummyMeter);
+}
+
+#[test]
+#[should_panic]
+fn test_vec_imm_borrow_no_arg() {
+    let code = vec![Bytecode::VecImmBorrow(SignatureIndex(3))];
+    let mut module = make_module_with_local(code, SignatureToken::Vector(Box::new(SignatureToken::U32)));
+    module.signatures.push(Signature(vec![SignatureToken::U32]));
+    let fun_context = get_fun_context(&module);
+    let _result = type_safety::verify(&module, &fun_context, &mut DummyMeter);
+}

--- a/crates/move-bytecode-verifier/src/type_safety_tests/mod.rs
+++ b/crates/move-bytecode-verifier/src/type_safety_tests/mod.rs
@@ -574,3 +574,23 @@ fn test_branch_nop_ok() {
         assert!(result.is_ok());
     }
 }
+
+
+#[test]
+fn test_ld_integers_ok() {
+    for instr in vec![
+        Bytecode::LdU8(42),
+        Bytecode::LdU16(257),
+        Bytecode::LdU32(89),
+        Bytecode::LdU64(94),
+        Bytecode::LdU128(Box::new(9999)),
+        Bytecode::LdU256(Box::new(U256::from(745_u32))),
+    ] {
+        let code = vec![instr];
+        let module = make_module(code);
+        let fun_context = get_fun_context(&module);
+        let result = type_safety::verify(&module, &fun_context, &mut DummyMeter);
+        assert!(result.is_ok());
+    }
+}
+

--- a/crates/move-bytecode-verifier/src/type_safety_tests/mod.rs
+++ b/crates/move-bytecode-verifier/src/type_safety_tests/mod.rs
@@ -2246,6 +2246,112 @@ fn test_move_from_deprecated_no_arg() {
 }
 
 #[test]
+fn test_move_to_deprecated_correct_type() {
+    let code = vec![
+        Bytecode::ImmBorrowLoc(0),
+        Bytecode::LdU32(42),
+        Bytecode::Pack(StructDefinitionIndex(0)),
+        Bytecode::MoveToDeprecated(StructDefinitionIndex(0)),
+    ];
+    let mut module = make_module_with_local(code, SignatureToken::Signer);
+    add_simple_struct_with_abilities(&mut module, AbilitySet::ALL);
+    let fun_context = get_fun_context(&module);
+    let result = type_safety::verify(&module, &fun_context, &mut DummyMeter);
+    assert!(result.is_ok());
+}
+
+#[test]
+fn test_move_to_deprecated_mismatched_types() {
+    let code = vec![
+        Bytecode::ImmBorrowLoc(0),
+        Bytecode::LdU32(42),
+        Bytecode::MoveToDeprecated(StructDefinitionIndex(0)),
+    ];
+    let mut module = make_module_with_local(code, SignatureToken::Signer);
+    add_simple_struct_with_abilities(&mut module, AbilitySet::ALL);
+    let fun_context = get_fun_context(&module);
+    let result = type_safety::verify(&module, &fun_context, &mut DummyMeter);
+    assert_eq!(
+        result.unwrap_err().major_status(),
+        StatusCode::MOVETO_TYPE_MISMATCH_ERROR
+    );
+}
+
+#[test]
+fn test_move_to_deprecated_wrong_type() {
+    let code = vec![
+        Bytecode::MutBorrowLoc(0),
+        Bytecode::LdU32(42),
+        Bytecode::Pack(StructDefinitionIndex(0)),
+        Bytecode::MoveToDeprecated(StructDefinitionIndex(0)),
+    ];
+    let mut module = make_module_with_local(code, SignatureToken::Signer);
+    add_simple_struct_with_abilities(&mut module, AbilitySet::ALL);
+    let fun_context = get_fun_context(&module);
+    let result = type_safety::verify(&module, &fun_context, &mut DummyMeter);
+    assert_eq!(
+        result.unwrap_err().major_status(),
+        StatusCode::MOVETO_TYPE_MISMATCH_ERROR
+    );
+
+    let code = vec![
+        Bytecode::ImmBorrowLoc(0),
+        Bytecode::LdU32(42),
+        Bytecode::Pack(StructDefinitionIndex(0)),
+        Bytecode::MoveToDeprecated(StructDefinitionIndex(0)),
+    ];
+    let mut module = make_module_with_local(code, SignatureToken::U32);
+    add_simple_struct_with_abilities(&mut module, AbilitySet::ALL);
+    let fun_context = get_fun_context(&module);
+    let result = type_safety::verify(&module, &fun_context, &mut DummyMeter);
+    assert_eq!(
+        result.unwrap_err().major_status(),
+        StatusCode::MOVETO_TYPE_MISMATCH_ERROR
+    );
+}
+
+#[test]
+fn test_move_to_deprecated_no_key() {
+    let code = vec![
+        Bytecode::ImmBorrowLoc(0),
+        Bytecode::LdU32(42),
+        Bytecode::Pack(StructDefinitionIndex(0)),
+        Bytecode::MoveToDeprecated(StructDefinitionIndex(0)),
+    ];
+    let mut module = make_module_with_local(code, SignatureToken::Signer);
+    add_simple_struct_with_abilities(&mut module, AbilitySet::PRIMITIVES);
+    let fun_context = get_fun_context(&module);
+    let result = type_safety::verify(&module, &fun_context, &mut DummyMeter);
+    assert_eq!(
+        result.unwrap_err().major_status(),
+        StatusCode::MOVETO_WITHOUT_KEY_ABILITY
+    );
+}
+
+#[test]
+#[should_panic]
+fn test_move_to_too_few_args() {
+    let code = vec![
+        Bytecode::ImmBorrowLoc(0),
+        Bytecode::MoveToDeprecated(StructDefinitionIndex(0)),
+    ];
+    let mut module = make_module_with_local(code, SignatureToken::Signer);
+    add_simple_struct_with_abilities(&mut module, AbilitySet::ALL);
+    let fun_context = get_fun_context(&module);
+    let _result = type_safety::verify(&module, &fun_context, &mut DummyMeter);
+}
+
+#[test]
+#[should_panic]
+fn test_move_to_deprecated_no_arg() {
+    let code = vec![Bytecode::MoveToDeprecated(StructDefinitionIndex(0))];
+    let mut module = make_module_with_local(code, SignatureToken::Signer);
+    add_simple_struct_with_abilities(&mut module, AbilitySet::ALL);
+    let fun_context = get_fun_context(&module);
+    let _result = type_safety::verify(&module, &fun_context, &mut DummyMeter);
+}
+
+#[test]
 fn test_borrow_global_deprecated_correct_type() {
     for instr in vec![
         Bytecode::ImmBorrowGlobalDeprecated(StructDefinitionIndex(0)),

--- a/crates/move-bytecode-verifier/src/type_safety_tests/mod.rs
+++ b/crates/move-bytecode-verifier/src/type_safety_tests/mod.rs
@@ -2189,3 +2189,58 @@ fn test_exists_deprecated_no_arg() {
     let fun_context = get_fun_context(&module);
     let _result = type_safety::verify(&module, &fun_context, &mut DummyMeter);
 }
+
+#[test]
+fn test_move_from_deprecated_correct_type() {
+    let code = vec![
+        Bytecode::CopyLoc(0),
+        Bytecode::MoveFromDeprecated(StructDefinitionIndex(0)),
+    ];
+    let mut module = make_module_with_local(code, SignatureToken::Address);
+    add_simple_struct_with_abilities(&mut module, AbilitySet::ALL);
+    let fun_context = get_fun_context(&module);
+    let result = type_safety::verify(&module, &fun_context, &mut DummyMeter);
+    assert!(result.is_ok());
+}
+
+#[test]
+fn test_move_from_deprecated_wrong_type() {
+    let code = vec![
+        Bytecode::LdU64(42),
+        Bytecode::MoveFromDeprecated(StructDefinitionIndex(0)),
+    ];
+    let mut module = make_module_with_local(code, SignatureToken::Address);
+    add_simple_struct_with_abilities(&mut module, AbilitySet::ALL);
+    let fun_context = get_fun_context(&module);
+    let result = type_safety::verify(&module, &fun_context, &mut DummyMeter);
+    assert_eq!(
+        result.unwrap_err().major_status(),
+        StatusCode::MOVEFROM_TYPE_MISMATCH_ERROR
+    );
+}
+
+#[test]
+fn test_move_from_deprecated_no_key() {
+    let code = vec![
+        Bytecode::CopyLoc(0),
+        Bytecode::MoveFromDeprecated(StructDefinitionIndex(0)),
+    ];
+    let mut module = make_module_with_local(code, SignatureToken::Address);
+    add_simple_struct_with_abilities(&mut module, AbilitySet::PRIMITIVES);
+    let fun_context = get_fun_context(&module);
+    let result = type_safety::verify(&module, &fun_context, &mut DummyMeter);
+    assert_eq!(
+        result.unwrap_err().major_status(),
+        StatusCode::MOVEFROM_WITHOUT_KEY_ABILITY
+    );
+}
+
+#[test]
+#[should_panic]
+fn test_move_from_deprecated_no_arg() {
+    let code = vec![Bytecode::MoveFromDeprecated(StructDefinitionIndex(0))];
+    let mut module = make_module_with_local(code, SignatureToken::Address);
+    add_simple_struct_with_abilities(&mut module, AbilitySet::ALL);
+    let fun_context = get_fun_context(&module);
+    let _result = type_safety::verify(&module, &fun_context, &mut DummyMeter);
+}

--- a/crates/move-bytecode-verifier/src/type_safety_tests/mod.rs
+++ b/crates/move-bytecode-verifier/src/type_safety_tests/mod.rs
@@ -1428,3 +1428,50 @@ fn test_call_too_few_args() {
     let fun_context = get_fun_context(&module);
     let _result = type_safety::verify(&module, &fun_context, &mut DummyMeter);
 }
+
+#[test]
+fn test_vec_pack_correct_type() {
+    let code = vec![
+        Bytecode::LdU32(33),
+        Bytecode::LdU32(42),
+        Bytecode::LdU32(51),
+        Bytecode::VecPack(SignatureIndex(1), 3),
+    ];
+    let module = make_module(code);
+    let fun_context = get_fun_context(&module);
+    let result = type_safety::verify(&module, &fun_context, &mut DummyMeter);
+    assert!(result.is_ok());
+}
+
+#[test]
+fn test_vec_pack_wrong_type() {
+    let code = vec![
+        Bytecode::LdU32(33),
+        Bytecode::LdU64(42),
+        Bytecode::LdU32(51),
+        Bytecode::VecPack(SignatureIndex(1), 3),
+    ];
+    let module = make_module(code);
+    let fun_context = get_fun_context(&module);
+    let result = type_safety::verify(&module, &fun_context, &mut DummyMeter);
+    assert_eq!(
+        result.unwrap_err().major_status(),
+        StatusCode::TYPE_MISMATCH
+    );
+}
+
+#[test]
+fn test_vec_pack_too_few_args() {
+    let code = vec![
+        Bytecode::LdU32(33),
+        Bytecode::LdU32(51),
+        Bytecode::VecPack(SignatureIndex(1), 3),
+    ];
+    let module = make_module(code);
+    let fun_context = get_fun_context(&module);
+    let result = type_safety::verify(&module, &fun_context, &mut DummyMeter);
+    assert_eq!(
+        result.unwrap_err().major_status(),
+        StatusCode::TYPE_MISMATCH
+    );
+}

--- a/crates/move-bytecode-verifier/src/type_safety_tests/mod.rs
+++ b/crates/move-bytecode-verifier/src/type_safety_tests/mod.rs
@@ -995,3 +995,36 @@ fn test_borrow_loc_reference() {
         }
     }
 }
+
+
+#[test]
+fn test_copy_loc_ok() {
+    let code = vec![Bytecode::CopyLoc(0)];
+    let module = make_module_with_local(code, SignatureToken::U64);
+    let fun_context = get_fun_context(&module);
+    let result = type_safety::verify(&module, &fun_context, &mut DummyMeter);
+    assert!(result.is_ok());
+}
+
+#[test]
+fn test_copy_loc_no_copy() {
+    let code = vec![Bytecode::CopyLoc(0)];
+    let mut module = make_module_with_local(code, SignatureToken::Struct(StructHandleIndex(0)));
+    add_simple_struct_with_abilities(&mut module, AbilitySet::EMPTY);
+    let fun_context = get_fun_context(&module);
+    let result = type_safety::verify(&module, &fun_context, &mut DummyMeter);
+    assert_eq!(
+        result.unwrap_err().major_status(),
+        StatusCode::COPYLOC_WITHOUT_COPY_ABILITY
+    );
+}
+
+
+#[test]
+fn test_move_loc_ok() {
+    let code = vec![Bytecode::MoveLoc(0)];
+    let module = make_module_with_local(code, SignatureToken::U64);
+    let fun_context = get_fun_context(&module);
+    let result = type_safety::verify(&module, &fun_context, &mut DummyMeter);
+    assert!(result.is_ok());
+}

--- a/crates/move-bytecode-verifier/src/type_safety_tests/mod.rs
+++ b/crates/move-bytecode-verifier/src/type_safety_tests/mod.rs
@@ -462,3 +462,99 @@ fn test_not_no_arg() {
     let fun_context = get_fun_context(&module);
     let _result = type_safety::verify(&module, &fun_context, &mut DummyMeter);
 }
+
+
+#[test]
+fn test_comparison_correct_types() {
+    for instr in vec![
+        Bytecode::Lt,
+        Bytecode::Gt,
+        Bytecode::Le,
+        Bytecode::Ge,
+        Bytecode::Eq,
+        Bytecode::Neq,
+    ] {
+        for push_ty_instr in vec![
+            Bytecode::LdU8(42),
+            Bytecode::LdU16(257),
+            Bytecode::LdU32(89),
+            Bytecode::LdU64(94),
+            Bytecode::LdU128(Box::new(9999)),
+            Bytecode::LdU256(Box::new(U256::from(745_u32))),
+        ] {
+            let code = vec![push_ty_instr.clone(), push_ty_instr.clone(), instr.clone()];
+            let module = make_module(code);
+            let fun_context = get_fun_context(&module);
+            let result = type_safety::verify(&module, &fun_context, &mut DummyMeter);
+            assert!(result.is_ok());
+        }
+    }
+}
+
+#[test]
+fn test_comparison_mismatched_types() {
+    for instr in vec![
+        Bytecode::Lt,
+        Bytecode::Gt,
+        Bytecode::Le,
+        Bytecode::Ge,
+    ] {
+        let code = vec![Bytecode::LdU8(42), Bytecode::LdU64(94), instr.clone()];
+        let module = make_module(code);
+        let fun_context = get_fun_context(&module);
+        let result = type_safety::verify(&module, &fun_context, &mut DummyMeter);
+        assert_eq!(
+            result.unwrap_err().major_status(),
+            StatusCode::INTEGER_OP_TYPE_MISMATCH_ERROR
+        );
+    }
+}
+
+#[test]
+fn test_comparison_wrong_type() {
+    for instr in vec![
+        Bytecode::Lt,
+        Bytecode::Gt,
+        Bytecode::Le,
+        Bytecode::Ge,
+    ] {
+        let code = vec![Bytecode::LdTrue, Bytecode::LdU64(94), instr.clone()];
+        let module = make_module(code);
+        let fun_context = get_fun_context(&module);
+        let result = type_safety::verify(&module, &fun_context, &mut DummyMeter);
+        assert_eq!(
+            result.unwrap_err().major_status(),
+            StatusCode::INTEGER_OP_TYPE_MISMATCH_ERROR
+        );
+
+        let code = vec![Bytecode::LdU32(94), Bytecode::LdFalse, instr.clone()];
+        let module = make_module(code);
+        let fun_context = get_fun_context(&module);
+        let result = type_safety::verify(&module, &fun_context, &mut DummyMeter);
+        assert_eq!(
+            result.unwrap_err().major_status(),
+            StatusCode::INTEGER_OP_TYPE_MISMATCH_ERROR
+        );
+    }
+}
+
+#[test]
+#[should_panic]
+fn test_comparison_too_few_args() {
+    for instr in vec![
+        Bytecode::Lt,
+        Bytecode::Gt,
+        Bytecode::Le,
+        Bytecode::Ge,
+    ] {
+        let code = vec![Bytecode::LdU16(42), instr.clone()];
+        let module = make_module(code);
+        let fun_context = get_fun_context(&module);
+        let _result = type_safety::verify(&module, &fun_context, &mut DummyMeter);
+
+        let code = vec![instr.clone()];
+        let module = make_module(code);
+        let fun_context = get_fun_context(&module);
+        let _result = type_safety::verify(&module, &fun_context, &mut DummyMeter);
+    }
+}

--- a/crates/move-bytecode-verifier/src/type_safety_tests/mod.rs
+++ b/crates/move-bytecode-verifier/src/type_safety_tests/mod.rs
@@ -1796,3 +1796,116 @@ fn test_vec_mut_borrow_no_arg() {
     let fun_context = get_fun_context(&module);
     let _result = type_safety::verify(&module, &fun_context, &mut DummyMeter);
 }
+
+#[test]
+fn test_vec_push_back_correct_type() {
+    let code = vec![
+        Bytecode::MutBorrowLoc(0),
+        Bytecode::LdU32(42),
+        Bytecode::VecPushBack(SignatureIndex(3)),
+    ];
+    let mut module = make_module_with_local(code, SignatureToken::Vector(Box::new(SignatureToken::U32)));
+    module.signatures.push(Signature(vec![SignatureToken::U32]));
+    let fun_context = get_fun_context(&module);
+    let result = type_safety::verify(&module, &fun_context, &mut DummyMeter);
+    assert!(result.is_ok());
+}
+
+#[test]
+fn test_vec_push_back_type_mismatch() {
+    let code = vec![
+        Bytecode::MutBorrowLoc(0),
+        Bytecode::LdFalse,
+        Bytecode::VecPushBack(SignatureIndex(3)),
+    ];
+    let mut module = make_module_with_local(code, SignatureToken::Vector(Box::new(SignatureToken::U32)));
+    module.signatures.push(Signature(vec![SignatureToken::U32]));
+    let fun_context = get_fun_context(&module);
+    let result = type_safety::verify(&module, &fun_context, &mut DummyMeter);
+    assert_eq!(
+        result.unwrap_err().major_status(),
+        StatusCode::TYPE_MISMATCH
+    );
+
+    let code = vec![
+        Bytecode::MutBorrowLoc(0),
+        Bytecode::LdU32(51),
+        Bytecode::VecPushBack(SignatureIndex(3)),
+    ];
+    let mut module = make_module_with_local(code, SignatureToken::Vector(Box::new(SignatureToken::U64)));
+    module.signatures.push(Signature(vec![SignatureToken::U32]));
+    let fun_context = get_fun_context(&module);
+    let result = type_safety::verify(&module, &fun_context, &mut DummyMeter);
+    assert_eq!(
+        result.unwrap_err().major_status(),
+        StatusCode::TYPE_MISMATCH
+    );
+
+    let code = vec![
+        Bytecode::MutBorrowLoc(0),
+        Bytecode::LdU32(51),
+        Bytecode::VecPushBack(SignatureIndex(3)),
+    ];
+    let mut module = make_module_with_local(code, SignatureToken::Vector(Box::new(SignatureToken::U32)));
+    module.signatures.push(Signature(vec![SignatureToken::U64]));
+    let fun_context = get_fun_context(&module);
+    let result = type_safety::verify(&module, &fun_context, &mut DummyMeter);
+    assert_eq!(
+        result.unwrap_err().major_status(),
+        StatusCode::TYPE_MISMATCH
+    );
+}
+
+#[test]
+fn test_vec_push_back_wrong_type() {
+    let code = vec![
+        Bytecode::LdTrue,
+        Bytecode::LdU32(42),
+        Bytecode::VecPushBack(SignatureIndex(3)),
+    ];
+    let mut module = make_module_with_local(code, SignatureToken::Vector(Box::new(SignatureToken::U32)));
+    module.signatures.push(Signature(vec![SignatureToken::U32]));
+    let fun_context = get_fun_context(&module);
+    let result = type_safety::verify(&module, &fun_context, &mut DummyMeter);
+    assert_eq!(
+        result.unwrap_err().major_status(),
+        StatusCode::TYPE_MISMATCH
+    );
+
+    let code = vec![
+        Bytecode::ImmBorrowLoc(0),
+        Bytecode::LdU32(42),
+        Bytecode::VecPushBack(SignatureIndex(3)),
+    ];
+    let mut module = make_module_with_local(code, SignatureToken::Vector(Box::new(SignatureToken::U32)));
+    module.signatures.push(Signature(vec![SignatureToken::U32]));
+    let fun_context = get_fun_context(&module);
+    let result = type_safety::verify(&module, &fun_context, &mut DummyMeter);
+    assert_eq!(
+        result.unwrap_err().major_status(),
+        StatusCode::TYPE_MISMATCH
+    );
+}
+
+#[test]
+#[should_panic]
+fn test_vec_push_back_too_few_args() {
+    let code = vec![
+        Bytecode::MutBorrowLoc(0),
+        Bytecode::VecPushBack(SignatureIndex(3)),
+    ];
+    let mut module = make_module_with_local(code, SignatureToken::Vector(Box::new(SignatureToken::U32)));
+    module.signatures.push(Signature(vec![SignatureToken::U32]));
+    let fun_context = get_fun_context(&module);
+    let _result = type_safety::verify(&module, &fun_context, &mut DummyMeter);
+}
+
+#[test]
+#[should_panic]
+fn test_vec_push_back_no_arg() {
+    let code = vec![Bytecode::VecPushBack(SignatureIndex(3))];
+    let mut module = make_module_with_local(code, SignatureToken::Vector(Box::new(SignatureToken::U32)));
+    module.signatures.push(Signature(vec![SignatureToken::U32]));
+    let fun_context = get_fun_context(&module);
+    let _result = type_safety::verify(&module, &fun_context, &mut DummyMeter);
+}

--- a/crates/move-bytecode-verifier/src/type_safety_tests/mod.rs
+++ b/crates/move-bytecode-verifier/src/type_safety_tests/mod.rs
@@ -48,17 +48,26 @@ fn get_fun_context(module: &CompiledModule) -> FunctionContext {
 
 
 #[test]
-fn test_br_true_correct_type() {
-    let code = vec![Bytecode::LdTrue, Bytecode::BrTrue(0)];
+fn test_br_true_false_correct_type() {
+    for instr in vec![
+        Bytecode::BrTrue(0),
+        Bytecode::BrFalse(0),
+    ] {
+        let code = vec![Bytecode::LdTrue, instr];
     let module = make_module(code);
     let fun_context = get_fun_context(&module);
     let result = type_safety::verify(&module, &fun_context, &mut DummyMeter);
     assert!(result.is_ok());
 }
+}
 
 #[test]
-fn test_br_true_wrong_type() {
-    let code = vec![Bytecode::LdU32(0), Bytecode::BrTrue(0)];
+fn test_br_true_false_wrong_type() {
+    for instr in vec![
+        Bytecode::BrTrue(0),
+        Bytecode::BrFalse(0),
+    ] {
+        let code = vec![Bytecode::LdU32(0), instr];
     let module = make_module(code);
     let fun_context = get_fun_context(&module);
     let result = type_safety::verify(&module, &fun_context, &mut DummyMeter);
@@ -66,46 +75,21 @@ fn test_br_true_wrong_type() {
         result.unwrap_err().major_status(),
         StatusCode::BR_TYPE_MISMATCH_ERROR
     );
+    }
 }
 
 #[test]
 #[should_panic]
-fn test_br_true_no_arg() {
-    let code = vec![Bytecode::BrTrue(0)];
+fn test_br_true_false_no_arg() {
+    for instr in vec![
+        Bytecode::BrTrue(0),
+        Bytecode::BrFalse(0),
+    ] {
+        let code = vec![instr];
     let module = make_module(code);
     let fun_context = get_fun_context(&module);
     let _result = type_safety::verify(&module, &fun_context, &mut DummyMeter);
-}
-
-
-#[test]
-fn test_br_false_correct_type() {
-    let code = vec![Bytecode::LdTrue, Bytecode::BrFalse(0)];
-    let module = make_module(code);
-    let fun_context = get_fun_context(&module);
-    let result = type_safety::verify(&module, &fun_context, &mut DummyMeter);
-    assert!(result.is_ok());
-}
-
-#[test]
-fn test_br_false_wrong_type() {
-    let code = vec![Bytecode::LdU32(0), Bytecode::BrFalse(0)];
-    let module = make_module(code);
-    let fun_context = get_fun_context(&module);
-    let result = type_safety::verify(&module, &fun_context, &mut DummyMeter);
-    assert_eq!(
-        result.unwrap_err().major_status(),
-        StatusCode::BR_TYPE_MISMATCH_ERROR
-    );
-}
-
-#[test]
-#[should_panic]
-fn test_br_false_no_arg() {
-    let code = vec![Bytecode::BrFalse(0)];
-    let module = make_module(code);
-    let fun_context = get_fun_context(&module);
-    let _result = type_safety::verify(&module, &fun_context, &mut DummyMeter);
+    }
 }
 
 

--- a/crates/move-bytecode-verifier/src/type_safety_tests/mod.rs
+++ b/crates/move-bytecode-verifier/src/type_safety_tests/mod.rs
@@ -1,23 +1,23 @@
 use move_binary_format::file_format::{
-    empty_module, Bytecode, CodeUnit, FunctionDefinition, FunctionDefinitionIndex, FunctionHandle, IdentifierIndex, ModuleHandleIndex, SignatureIndex, StructDefinitionIndex
+    empty_module, Bytecode, CodeUnit, FunctionDefinition, FunctionDefinitionIndex, FunctionHandle,
+    IdentifierIndex, ModuleHandleIndex, SignatureIndex, StructDefinitionIndex,
 };
 
-use move_core_types::{
-    u256::U256, vm_status::StatusCode,
-};
+use move_core_types::{u256::U256, vm_status::StatusCode};
 
 use move_binary_format::{
-    CompiledModule,
     file_format::{
-        ConstantPoolIndex, Constant, SignatureToken, AbilitySet, StructHandle, TypeSignature, FieldDefinition, StructHandleIndex, StructFieldInformation, StructDefinition, Signature, FieldHandleIndex, FieldHandle, FunctionHandleIndex
+        AbilitySet, Constant, ConstantPoolIndex, FieldDefinition, FieldHandle, FieldHandleIndex,
+        FunctionHandleIndex, Signature, SignatureToken, StructDefinition, StructFieldInformation,
+        StructHandle, StructHandleIndex, TypeSignature,
     },
+    CompiledModule,
 };
 
-use move_bytecode_verifier_meter::dummy::DummyMeter;
 use crate::absint::FunctionContext;
 use crate::constants;
 use crate::type_safety;
-
+use move_bytecode_verifier_meter::dummy::DummyMeter;
 
 fn make_module(code: Vec<Bytecode>) -> CompiledModule {
     make_module_with_ret(code, SignatureToken::U32)
@@ -45,10 +45,7 @@ fn make_module_with_ret(code: Vec<Bytecode>, return_: SignatureToken) -> Compile
     let mut module = empty_module();
     module.function_handles.push(fun_handle);
     module.function_defs.push(fun_def);
-    module.signatures = vec![
-        Signature(vec![]),
-        Signature(vec![return_]),
-    ];
+    module.signatures = vec![Signature(vec![]), Signature(vec![return_])];
 
     module
 }
@@ -75,9 +72,7 @@ fn make_module_with_local(code: Vec<Bytecode>, signature: SignatureToken) -> Com
     let mut module = empty_module();
     module.function_handles.push(fun_handle);
     module.function_defs.push(fun_def);
-    module.signatures = vec![
-        Signature(vec![signature]),
-    ];
+    module.signatures = vec![Signature(vec![signature])];
 
     module
 }
@@ -119,12 +114,10 @@ fn add_native_struct(module: &mut CompiledModule) {
     module.struct_defs.push(struct_def);
     module.struct_handles.push(struct_handle);
 
-    module.field_handles = vec![
-        FieldHandle {
-            owner: StructDefinitionIndex(0),
-            field: 0,
-        },
-    ];
+    module.field_handles = vec![FieldHandle {
+        owner: StructDefinitionIndex(0),
+        field: 0,
+    }];
 }
 
 fn add_simple_struct(module: &mut CompiledModule) {
@@ -148,7 +141,7 @@ fn add_simple_struct(module: &mut CompiledModule) {
         abilities: AbilitySet::EMPTY,
         type_parameters: vec![],
     };
-    
+
     module.struct_defs.push(struct_def);
     module.struct_handles.push(struct_handle);
 
@@ -160,20 +153,17 @@ fn add_simple_struct(module: &mut CompiledModule) {
         FieldHandle {
             owner: StructDefinitionIndex(0),
             field: 1,
-        }
+        },
     ];
 }
-
 
 fn add_simple_struct_with_abilities(module: &mut CompiledModule, abilities: AbilitySet) {
     let struct_def = StructDefinition {
         struct_handle: StructHandleIndex(0),
-        field_information: StructFieldInformation::Declared(vec![
-            FieldDefinition {
-                name: IdentifierIndex(5),
-                signature: TypeSignature(SignatureToken::U32),
-            },
-        ]),
+        field_information: StructFieldInformation::Declared(vec![FieldDefinition {
+            name: IdentifierIndex(5),
+            signature: TypeSignature(SignatureToken::U32),
+        }]),
     };
 
     let struct_handle = StructHandle {
@@ -187,23 +177,18 @@ fn add_simple_struct_with_abilities(module: &mut CompiledModule, abilities: Abil
     module.struct_handles.push(struct_handle);
 }
 
-
 fn get_fun_context(module: &CompiledModule) -> FunctionContext {
     FunctionContext::new(
         &module,
-        FunctionDefinitionIndex(0), 
+        FunctionDefinitionIndex(0),
         module.function_defs[0].code.as_ref().unwrap(),
         &module.function_handles[0],
     )
 }
 
-
 #[test]
 fn test_br_true_false_correct_type() {
-    for instr in vec![
-        Bytecode::BrTrue(0),
-        Bytecode::BrFalse(0),
-    ] {
+    for instr in vec![Bytecode::BrTrue(0), Bytecode::BrFalse(0)] {
         let code = vec![Bytecode::LdTrue, instr];
         let module = make_module(code);
         let fun_context = get_fun_context(&module);
@@ -214,10 +199,7 @@ fn test_br_true_false_correct_type() {
 
 #[test]
 fn test_br_true_false_wrong_type() {
-    for instr in vec![
-        Bytecode::BrTrue(0),
-        Bytecode::BrFalse(0),
-    ] {
+    for instr in vec![Bytecode::BrTrue(0), Bytecode::BrFalse(0)] {
         let code = vec![Bytecode::LdU32(0), instr];
         let module = make_module(code);
         let fun_context = get_fun_context(&module);
@@ -232,17 +214,13 @@ fn test_br_true_false_wrong_type() {
 #[test]
 #[should_panic]
 fn test_br_true_false_no_arg() {
-    for instr in vec![
-        Bytecode::BrTrue(0),
-        Bytecode::BrFalse(0),
-    ] {
+    for instr in vec![Bytecode::BrTrue(0), Bytecode::BrFalse(0)] {
         let code = vec![instr];
         let module = make_module(code);
         let fun_context = get_fun_context(&module);
         let _result = type_safety::verify(&module, &fun_context, &mut DummyMeter);
     }
 }
-
 
 #[test]
 fn test_abort_correct_type() {
@@ -252,7 +230,6 @@ fn test_abort_correct_type() {
     let result = type_safety::verify(&module, &fun_context, &mut DummyMeter);
     assert!(result.is_ok());
 }
-
 
 #[test]
 fn test_abort_wrong_type() {
@@ -274,7 +251,6 @@ fn test_abort_no_arg() {
     let fun_context = get_fun_context(&module);
     let _result = type_safety::verify(&module, &fun_context, &mut DummyMeter);
 }
-
 
 #[test]
 fn test_cast_correct_type() {
@@ -332,8 +308,6 @@ fn test_cast_no_arg() {
         let _result = type_safety::verify(&module, &fun_context, &mut DummyMeter);
     }
 }
-
-
 
 #[test]
 fn test_arithmetic_correct_types() {
@@ -419,7 +393,6 @@ fn test_arithmetic_wrong_type() {
     }
 }
 
-
 #[test]
 #[should_panic]
 fn test_arithmetic_too_few_args() {
@@ -460,13 +433,9 @@ fn test_arithmetic_no_args() {
     }
 }
 
-
 #[test]
 fn test_shl_shr_correct_types() {
-    for instr in vec![
-        Bytecode::Shl,
-        Bytecode::Shr,
-    ] {
+    for instr in vec![Bytecode::Shl, Bytecode::Shr] {
         for push_ty_instr in vec![
             Bytecode::LdU8(42),
             Bytecode::LdU16(257),
@@ -486,10 +455,7 @@ fn test_shl_shr_correct_types() {
 
 #[test]
 fn test_shl_shr_first_operand_wrong_type() {
-    for instr in vec![
-        Bytecode::Shl,
-        Bytecode::Shr,
-    ] {
+    for instr in vec![Bytecode::Shl, Bytecode::Shr] {
         let code = vec![Bytecode::LdTrue, Bytecode::LdU8(2), instr.clone()];
         let module = make_module(code);
         let fun_context = get_fun_context(&module);
@@ -503,10 +469,7 @@ fn test_shl_shr_first_operand_wrong_type() {
 
 #[test]
 fn test_shl_shr_second_operand_wrong_type() {
-    for instr in vec![
-        Bytecode::Shl,
-        Bytecode::Shr,
-    ] {
+    for instr in vec![Bytecode::Shl, Bytecode::Shr] {
         let code = vec![Bytecode::LdU32(42), Bytecode::LdU16(2), instr.clone()];
         let module = make_module(code);
         let fun_context = get_fun_context(&module);
@@ -521,25 +484,18 @@ fn test_shl_shr_second_operand_wrong_type() {
 #[test]
 #[should_panic]
 fn test_shl_shr_too_few_args() {
-    for instr in vec![
-        Bytecode::Shl,
-        Bytecode::Shr,
-    ] {
+    for instr in vec![Bytecode::Shl, Bytecode::Shr] {
         let code = vec![Bytecode::LdU16(42), instr.clone()];
         let module = make_module(code);
         let fun_context = get_fun_context(&module);
         let _result = type_safety::verify(&module, &fun_context, &mut DummyMeter);
-
     }
 }
 
 #[test]
 #[should_panic]
 fn test_shl_shr_no_args() {
-    for instr in vec![
-        Bytecode::Shl,
-        Bytecode::Shr,
-    ] {
+    for instr in vec![Bytecode::Shl, Bytecode::Shr] {
         let code = vec![instr.clone()];
         let module = make_module(code);
         let fun_context = get_fun_context(&module);
@@ -547,13 +503,9 @@ fn test_shl_shr_no_args() {
     }
 }
 
-
 #[test]
 fn test_or_and_correct_types() {
-    for instr in vec![
-        Bytecode::Or,
-        Bytecode::And,
-    ] {
+    for instr in vec![Bytecode::Or, Bytecode::And] {
         let code = vec![Bytecode::LdFalse, Bytecode::LdTrue, instr.clone()];
         let module = make_module(code);
         let fun_context = get_fun_context(&module);
@@ -564,10 +516,7 @@ fn test_or_and_correct_types() {
 
 #[test]
 fn test_or_and_wrong_types() {
-    for instr in vec![
-        Bytecode::Or,
-        Bytecode::And,
-    ] {
+    for instr in vec![Bytecode::Or, Bytecode::And] {
         let code = vec![Bytecode::LdU32(42), Bytecode::LdTrue, instr.clone()];
         let module = make_module(code);
         let fun_context = get_fun_context(&module);
@@ -591,10 +540,7 @@ fn test_or_and_wrong_types() {
 #[test]
 #[should_panic]
 fn test_or_and_too_few_args() {
-    for instr in vec![
-        Bytecode::Or,
-        Bytecode::And,
-    ] {
+    for instr in vec![Bytecode::Or, Bytecode::And] {
         let code = vec![Bytecode::LdTrue, instr.clone()];
         let module = make_module(code);
         let fun_context = get_fun_context(&module);
@@ -605,17 +551,13 @@ fn test_or_and_too_few_args() {
 #[test]
 #[should_panic]
 fn test_or_and_no_args() {
-    for instr in vec![
-        Bytecode::Or,
-        Bytecode::And,
-    ] {
+    for instr in vec![Bytecode::Or, Bytecode::And] {
         let code = vec![instr.clone()];
         let module = make_module(code);
         let fun_context = get_fun_context(&module);
         let _result = type_safety::verify(&module, &fun_context, &mut DummyMeter);
     }
 }
-
 
 #[test]
 fn test_not_correct_type() {
@@ -647,7 +589,6 @@ fn test_not_no_arg() {
     let _result = type_safety::verify(&module, &fun_context, &mut DummyMeter);
 }
 
-
 #[test]
 fn test_comparison_correct_types() {
     for instr in vec![
@@ -677,12 +618,7 @@ fn test_comparison_correct_types() {
 
 #[test]
 fn test_comparison_mismatched_types() {
-    for instr in vec![
-        Bytecode::Lt,
-        Bytecode::Gt,
-        Bytecode::Le,
-        Bytecode::Ge,
-    ] {
+    for instr in vec![Bytecode::Lt, Bytecode::Gt, Bytecode::Le, Bytecode::Ge] {
         let code = vec![Bytecode::LdU8(42), Bytecode::LdU64(94), instr.clone()];
         let module = make_module(code);
         let fun_context = get_fun_context(&module);
@@ -696,12 +632,7 @@ fn test_comparison_mismatched_types() {
 
 #[test]
 fn test_comparison_wrong_type() {
-    for instr in vec![
-        Bytecode::Lt,
-        Bytecode::Gt,
-        Bytecode::Le,
-        Bytecode::Ge,
-    ] {
+    for instr in vec![Bytecode::Lt, Bytecode::Gt, Bytecode::Le, Bytecode::Ge] {
         let code = vec![Bytecode::LdTrue, Bytecode::LdU64(94), instr.clone()];
         let module = make_module(code);
         let fun_context = get_fun_context(&module);
@@ -725,12 +656,7 @@ fn test_comparison_wrong_type() {
 #[test]
 #[should_panic]
 fn test_comparison_too_few_args() {
-    for instr in vec![
-        Bytecode::Lt,
-        Bytecode::Gt,
-        Bytecode::Le,
-        Bytecode::Ge,
-    ] {
+    for instr in vec![Bytecode::Lt, Bytecode::Gt, Bytecode::Le, Bytecode::Ge] {
         let code = vec![Bytecode::LdU16(42), instr.clone()];
         let module = make_module(code);
         let fun_context = get_fun_context(&module);
@@ -741,12 +667,7 @@ fn test_comparison_too_few_args() {
 #[test]
 #[should_panic]
 fn test_comparison_no_args() {
-    for instr in vec![
-        Bytecode::Lt,
-        Bytecode::Gt,
-        Bytecode::Le,
-        Bytecode::Ge,
-    ] {
+    for instr in vec![Bytecode::Lt, Bytecode::Gt, Bytecode::Le, Bytecode::Ge] {
         let code = vec![instr.clone()];
         let module = make_module(code);
         let fun_context = get_fun_context(&module);
@@ -754,14 +675,10 @@ fn test_comparison_no_args() {
     }
 }
 
-
 // these operation does not produce errors in verify_instr()
 #[test]
 fn test_branch_nop_ok() {
-    for instr in vec![
-        Bytecode::Branch(0),
-        Bytecode::Nop,
-    ] {
+    for instr in vec![Bytecode::Branch(0), Bytecode::Nop] {
         let code = vec![instr];
         let module = make_module(code);
         let fun_context = get_fun_context(&module);
@@ -769,7 +686,6 @@ fn test_branch_nop_ok() {
         assert!(result.is_ok());
     }
 }
-
 
 #[test]
 fn test_ld_integers_ok() {
@@ -789,13 +705,9 @@ fn test_ld_integers_ok() {
     }
 }
 
-
 #[test]
 fn test_ld_true_false_ok() {
-    for instr in vec![
-        Bytecode::LdTrue,
-        Bytecode::LdFalse,
-    ] {
+    for instr in vec![Bytecode::LdTrue, Bytecode::LdFalse] {
         let code = vec![instr];
         let module = make_module(code);
         let fun_context = get_fun_context(&module);
@@ -803,7 +715,6 @@ fn test_ld_true_false_ok() {
         assert!(result.is_ok());
     }
 }
-
 
 #[test]
 fn test_ld_const_ok() {
@@ -820,10 +731,13 @@ fn test_ld_const_ok() {
     assert!(result.is_ok());
 }
 
-
 #[test]
 fn test_pack_correct_types() {
-    let code = vec![Bytecode::LdU32(42), Bytecode::LdTrue, Bytecode::Pack(StructDefinitionIndex(0))];
+    let code = vec![
+        Bytecode::LdU32(42),
+        Bytecode::LdTrue,
+        Bytecode::Pack(StructDefinitionIndex(0)),
+    ];
     let mut module: CompiledModule = make_module(code);
     add_simple_struct(&mut module);
     let fun_context = get_fun_context(&module);
@@ -833,7 +747,11 @@ fn test_pack_correct_types() {
 
 #[test]
 fn test_pack_mismatched_types() {
-    let code = vec![Bytecode::LdTrue, Bytecode::LdU32(42), Bytecode::Pack(StructDefinitionIndex(0))];
+    let code = vec![
+        Bytecode::LdTrue,
+        Bytecode::LdU32(42),
+        Bytecode::Pack(StructDefinitionIndex(0)),
+    ];
     let mut module: CompiledModule = make_module(code);
     add_simple_struct(&mut module);
     let fun_context = get_fun_context(&module);
@@ -854,11 +772,11 @@ fn test_pack_too_few_args() {
     let _result = type_safety::verify(&module, &fun_context, &mut DummyMeter);
 }
 
-
 #[test]
 fn test_unpack_correct_types() {
     let code = vec![
-        Bytecode::LdU32(42), Bytecode::LdTrue,
+        Bytecode::LdU32(42),
+        Bytecode::LdTrue,
         Bytecode::Pack(StructDefinitionIndex(0)),
         Bytecode::Unpack(StructDefinitionIndex(0)),
     ];
@@ -871,7 +789,10 @@ fn test_unpack_correct_types() {
 
 #[test]
 fn test_unpack_wrong_type() {
-    let code = vec![Bytecode::LdU32(42), Bytecode::Unpack(StructDefinitionIndex(0))];
+    let code = vec![
+        Bytecode::LdU32(42),
+        Bytecode::Unpack(StructDefinitionIndex(0)),
+    ];
     let mut module: CompiledModule = make_module(code);
     add_simple_struct(&mut module);
     let fun_context = get_fun_context(&module);
@@ -892,13 +813,9 @@ fn test_unpack_no_arg() {
     let _result = type_safety::verify(&module, &fun_context, &mut DummyMeter);
 }
 
-
 #[test]
 fn test_eq_neq_correct_types() {
-    for instr in vec![
-        Bytecode::Eq,
-        Bytecode::Neq,
-    ] {
+    for instr in vec![Bytecode::Eq, Bytecode::Neq] {
         let code = vec![Bytecode::LdU32(42), Bytecode::LdU32(42), instr.clone()];
         let module = make_module(code);
         let fun_context = get_fun_context(&module);
@@ -910,7 +827,7 @@ fn test_eq_neq_correct_types() {
             Bytecode::Pack(StructDefinitionIndex(0)),
             Bytecode::LdU32(51),
             Bytecode::Pack(StructDefinitionIndex(0)),
-            instr.clone()
+            instr.clone(),
         ];
         let mut module = make_module(code);
         add_simple_struct_with_abilities(&mut module, AbilitySet::PRIMITIVES);
@@ -922,10 +839,7 @@ fn test_eq_neq_correct_types() {
 
 #[test]
 fn test_eq_neq_mismatched_types() {
-    for instr in vec![
-        Bytecode::Eq,
-        Bytecode::Neq,
-    ] {
+    for instr in vec![Bytecode::Eq, Bytecode::Neq] {
         let code = vec![Bytecode::LdU32(42), Bytecode::LdU64(42), instr.clone()];
         let module = make_module(code);
         let fun_context = get_fun_context(&module);
@@ -937,18 +851,15 @@ fn test_eq_neq_mismatched_types() {
     }
 }
 
-#[test] 
+#[test]
 fn test_eq_neq_no_drop() {
-    for instr in vec![
-        Bytecode::Eq,
-        Bytecode::Neq,
-    ] {
+    for instr in vec![Bytecode::Eq, Bytecode::Neq] {
         let code = vec![
             Bytecode::LdU32(42),
             Bytecode::Pack(StructDefinitionIndex(0)),
             Bytecode::LdU32(51),
             Bytecode::Pack(StructDefinitionIndex(0)),
-            instr.clone()
+            instr.clone(),
         ];
 
         let mut module = make_module(code);
@@ -965,10 +876,7 @@ fn test_eq_neq_no_drop() {
 #[test]
 #[should_panic]
 fn test_eq_neq_too_few_args() {
-    for instr in vec![
-        Bytecode::Eq,
-        Bytecode::Neq,
-    ] {
+    for instr in vec![Bytecode::Eq, Bytecode::Neq] {
         let code = vec![Bytecode::LdU32(42), instr.clone()];
         let module = make_module(code);
         let fun_context = get_fun_context(&module);
@@ -979,17 +887,13 @@ fn test_eq_neq_too_few_args() {
 #[test]
 #[should_panic]
 fn test_eq_neq_no_args() {
-    for instr in vec![
-        Bytecode::Eq,
-        Bytecode::Neq,
-    ] {
+    for instr in vec![Bytecode::Eq, Bytecode::Neq] {
         let code = vec![instr.clone()];
         let module = make_module(code);
         let fun_context = get_fun_context(&module);
         let _result = type_safety::verify(&module, &fun_context, &mut DummyMeter);
     }
 }
-
 
 #[test]
 fn test_pop_ok() {
@@ -1002,7 +906,11 @@ fn test_pop_ok() {
 
 #[test]
 fn test_pop_no_drop() {
-    let code = vec![Bytecode::LdU32(42), Bytecode::Pack(StructDefinitionIndex(0)), Bytecode::Pop];
+    let code = vec![
+        Bytecode::LdU32(42),
+        Bytecode::Pack(StructDefinitionIndex(0)),
+        Bytecode::Pop,
+    ];
     let mut module = make_module(code);
     add_simple_struct_with_abilities(&mut module, AbilitySet::EMPTY);
     let fun_context = get_fun_context(&module);
@@ -1022,13 +930,9 @@ fn test_pop_no_arg() {
     let _result = type_safety::verify(&module, &fun_context, &mut DummyMeter);
 }
 
-
 #[test]
 fn test_borrow_loc_ok() {
-    for instr in vec![
-        Bytecode::ImmBorrowLoc(1),
-        Bytecode::MutBorrowLoc(0),
-    ] {
+    for instr in vec![Bytecode::ImmBorrowLoc(1), Bytecode::MutBorrowLoc(0)] {
         let code = vec![instr];
         let module = make_module_with_local(code, SignatureToken::U64);
         let fun_context = get_fun_context(&module);
@@ -1039,10 +943,7 @@ fn test_borrow_loc_ok() {
 
 #[test]
 fn test_borrow_loc_reference() {
-    for instr in vec![
-        Bytecode::ImmBorrowLoc(1),
-        Bytecode::MutBorrowLoc(0),
-    ] {
+    for instr in vec![Bytecode::ImmBorrowLoc(1), Bytecode::MutBorrowLoc(0)] {
         for reference in vec![
             SignatureToken::Reference(Box::new(SignatureToken::U64)),
             SignatureToken::MutableReference(Box::new(SignatureToken::U32)),
@@ -1058,7 +959,6 @@ fn test_borrow_loc_reference() {
         }
     }
 }
-
 
 #[test]
 fn test_st_lock_correct_type() {
@@ -1090,7 +990,6 @@ fn test_st_lock_no_arg() {
     let _result = type_safety::verify(&module, &fun_context, &mut DummyMeter);
 }
 
-
 #[test]
 fn test_copy_loc_ok() {
     let code = vec![Bytecode::CopyLoc(0)];
@@ -1113,7 +1012,6 @@ fn test_copy_loc_no_copy() {
     );
 }
 
-
 #[test]
 fn test_move_loc_ok() {
     let code = vec![Bytecode::MoveLoc(0)];
@@ -1122,7 +1020,6 @@ fn test_move_loc_ok() {
     let result = type_safety::verify(&module, &fun_context, &mut DummyMeter);
     assert!(result.is_ok());
 }
-
 
 #[test]
 fn test_freeze_ref_correct_type() {
@@ -1163,13 +1060,9 @@ fn test_freeze_ref_no_arg() {
     let _result = type_safety::verify(&module, &fun_context, &mut DummyMeter);
 }
 
-
 #[test]
 fn test_read_ref_correct_type() {
-    for instr in vec![
-        Bytecode::ImmBorrowLoc(0),
-        Bytecode::MutBorrowLoc(0),
-    ] {
+    for instr in vec![Bytecode::ImmBorrowLoc(0), Bytecode::MutBorrowLoc(0)] {
         let code = vec![instr, Bytecode::ReadRef];
         let module = make_module_with_local(code, SignatureToken::U64);
         let fun_context = get_fun_context(&module);
@@ -1180,7 +1073,7 @@ fn test_read_ref_correct_type() {
 
 #[test]
 fn test_read_ref_wrong_type() {
-let code = vec![Bytecode::LdU64(42), Bytecode::ReadRef];
+    let code = vec![Bytecode::LdU64(42), Bytecode::ReadRef];
     let module = make_module_with_local(code, SignatureToken::U64);
     let fun_context = get_fun_context(&module);
     let result = type_safety::verify(&module, &fun_context, &mut DummyMeter);
@@ -1192,10 +1085,7 @@ let code = vec![Bytecode::LdU64(42), Bytecode::ReadRef];
 
 #[test]
 fn test_read_ref_no_copy() {
-    for instr in vec![
-        Bytecode::ImmBorrowLoc(0),
-        Bytecode::MutBorrowLoc(0),
-    ] {
+    for instr in vec![Bytecode::ImmBorrowLoc(0), Bytecode::MutBorrowLoc(0)] {
         let code = vec![instr, Bytecode::ReadRef];
         let mut module = make_module_with_local(code, SignatureToken::Struct(StructHandleIndex(0)));
         add_simple_struct_with_abilities(&mut module, AbilitySet::EMPTY);
@@ -1217,10 +1107,13 @@ fn test_read_ref_no_arg() {
     let _result = type_safety::verify(&module, &fun_context, &mut DummyMeter);
 }
 
-
 #[test]
 fn test_write_ref_correct_type() {
-    let code = vec![Bytecode::LdU64(42), Bytecode::MutBorrowLoc(0), Bytecode::WriteRef];
+    let code = vec![
+        Bytecode::LdU64(42),
+        Bytecode::MutBorrowLoc(0),
+        Bytecode::WriteRef,
+    ];
     let module = make_module_with_local(code, SignatureToken::U64);
     let fun_context = get_fun_context(&module);
     let result = type_safety::verify(&module, &fun_context, &mut DummyMeter);
@@ -1230,19 +1123,22 @@ fn test_write_ref_correct_type() {
         Bytecode::LdU32(42),
         Bytecode::Pack(StructDefinitionIndex(0)),
         Bytecode::MutBorrowLoc(0),
-        Bytecode::WriteRef
+        Bytecode::WriteRef,
     ];
     let mut module = make_module_with_local(code, SignatureToken::Struct(StructHandleIndex(0)));
     add_simple_struct_with_abilities(&mut module, AbilitySet::PRIMITIVES);
     let fun_context = get_fun_context(&module);
     let result = type_safety::verify(&module, &fun_context, &mut DummyMeter);
     assert!(result.is_ok());
-
 }
 
 #[test]
 fn test_write_ref_wrong_type() {
-    let code = vec![Bytecode::LdU64(42), Bytecode::ImmBorrowLoc(0), Bytecode::WriteRef];
+    let code = vec![
+        Bytecode::LdU64(42),
+        Bytecode::ImmBorrowLoc(0),
+        Bytecode::WriteRef,
+    ];
     let module = make_module_with_local(code, SignatureToken::U64);
     let fun_context = get_fun_context(&module);
     let result = type_safety::verify(&module, &fun_context, &mut DummyMeter);
@@ -1254,7 +1150,11 @@ fn test_write_ref_wrong_type() {
 
 #[test]
 fn test_write_ref_mismatched_types() {
-    let code = vec![Bytecode::LdU32(42), Bytecode::MutBorrowLoc(0), Bytecode::WriteRef];
+    let code = vec![
+        Bytecode::LdU32(42),
+        Bytecode::MutBorrowLoc(0),
+        Bytecode::WriteRef,
+    ];
     let module = make_module_with_local(code, SignatureToken::U64);
     let fun_context = get_fun_context(&module);
     let result = type_safety::verify(&module, &fun_context, &mut DummyMeter);
@@ -1270,7 +1170,7 @@ fn test_write_ref_no_drop() {
         Bytecode::LdU32(42),
         Bytecode::Pack(StructDefinitionIndex(0)),
         Bytecode::MutBorrowLoc(0),
-        Bytecode::WriteRef
+        Bytecode::WriteRef,
     ];
     let mut module = make_module_with_local(code, SignatureToken::Struct(StructHandleIndex(0)));
     add_simple_struct_with_abilities(&mut module, AbilitySet::EMPTY);
@@ -1300,10 +1200,12 @@ fn test_write_ref_no_args() {
     let _result = type_safety::verify(&module, &fun_context, &mut DummyMeter);
 }
 
-
 #[test]
 fn test_imm_borrow_field_correct_type() {
-    let code = vec![Bytecode::ImmBorrowLoc(0), Bytecode::ImmBorrowField(FieldHandleIndex(0))];
+    let code = vec![
+        Bytecode::ImmBorrowLoc(0),
+        Bytecode::ImmBorrowField(FieldHandleIndex(0)),
+    ];
     let mut module = make_module_with_local(code, SignatureToken::Struct(StructHandleIndex(0)));
     add_simple_struct(&mut module);
     let fun_context = get_fun_context(&module);
@@ -1313,7 +1215,10 @@ fn test_imm_borrow_field_correct_type() {
 
 #[test]
 fn test_imm_borrow_field_wrong_type() {
-    let code = vec![Bytecode::LdTrue, Bytecode::ImmBorrowField(FieldHandleIndex(0))];
+    let code = vec![
+        Bytecode::LdTrue,
+        Bytecode::ImmBorrowField(FieldHandleIndex(0)),
+    ];
     let mut module = make_module_with_local(code, SignatureToken::Struct(StructHandleIndex(0)));
     add_simple_struct(&mut module);
     let fun_context = get_fun_context(&module);
@@ -1326,7 +1231,10 @@ fn test_imm_borrow_field_wrong_type() {
 
 #[test]
 fn test_imm_borrow_field_mismatched_types() {
-    let code = vec![Bytecode::ImmBorrowLoc(0), Bytecode::ImmBorrowField(FieldHandleIndex(0))];
+    let code = vec![
+        Bytecode::ImmBorrowLoc(0),
+        Bytecode::ImmBorrowField(FieldHandleIndex(0)),
+    ];
     let mut module = make_module_with_local(code, SignatureToken::U64);
     add_simple_struct(&mut module);
     let fun_context = get_fun_context(&module);
@@ -1339,7 +1247,10 @@ fn test_imm_borrow_field_mismatched_types() {
 
 #[test]
 fn test_imm_borrow_field_bad_field() {
-    let code = vec![Bytecode::ImmBorrowLoc(0), Bytecode::ImmBorrowField(FieldHandleIndex(0))];
+    let code = vec![
+        Bytecode::ImmBorrowLoc(0),
+        Bytecode::ImmBorrowField(FieldHandleIndex(0)),
+    ];
     let mut module = make_module_with_local(code, SignatureToken::Struct(StructHandleIndex(0)));
     add_native_struct(&mut module);
     let fun_context = get_fun_context(&module);
@@ -1360,10 +1271,12 @@ fn test_imm_borrow_field_no_arg() {
     let _result = type_safety::verify(&module, &fun_context, &mut DummyMeter);
 }
 
-
 #[test]
 fn test_mut_borrow_field_correct_type() {
-    let code = vec![Bytecode::MutBorrowLoc(0), Bytecode::MutBorrowField(FieldHandleIndex(0))];
+    let code = vec![
+        Bytecode::MutBorrowLoc(0),
+        Bytecode::MutBorrowField(FieldHandleIndex(0)),
+    ];
     let mut module = make_module_with_local(code, SignatureToken::Struct(StructHandleIndex(0)));
     add_simple_struct(&mut module);
     let fun_context = get_fun_context(&module);
@@ -1373,7 +1286,10 @@ fn test_mut_borrow_field_correct_type() {
 
 #[test]
 fn test_mut_borrow_field_wrong_type() {
-    let code = vec![Bytecode::LdTrue, Bytecode::MutBorrowField(FieldHandleIndex(0))];
+    let code = vec![
+        Bytecode::LdTrue,
+        Bytecode::MutBorrowField(FieldHandleIndex(0)),
+    ];
     let mut module = make_module_with_local(code, SignatureToken::Struct(StructHandleIndex(0)));
     add_simple_struct(&mut module);
     let fun_context = get_fun_context(&module);
@@ -1383,7 +1299,10 @@ fn test_mut_borrow_field_wrong_type() {
         StatusCode::BORROWFIELD_TYPE_MISMATCH_ERROR
     );
 
-    let code = vec![Bytecode::ImmBorrowLoc(0), Bytecode::MutBorrowField(FieldHandleIndex(0))];
+    let code = vec![
+        Bytecode::ImmBorrowLoc(0),
+        Bytecode::MutBorrowField(FieldHandleIndex(0)),
+    ];
     let mut module = make_module_with_local(code, SignatureToken::Struct(StructHandleIndex(0)));
     add_simple_struct(&mut module);
     let fun_context = get_fun_context(&module);
@@ -1392,12 +1311,14 @@ fn test_mut_borrow_field_wrong_type() {
         result.unwrap_err().major_status(),
         StatusCode::BORROWFIELD_TYPE_MISMATCH_ERROR
     );
-
 }
 
 #[test]
 fn test_mut_borrow_field_mismatched_types() {
-    let code = vec![Bytecode::MutBorrowLoc(0), Bytecode::MutBorrowField(FieldHandleIndex(0))];
+    let code = vec![
+        Bytecode::MutBorrowLoc(0),
+        Bytecode::MutBorrowField(FieldHandleIndex(0)),
+    ];
     let mut module = make_module_with_local(code, SignatureToken::U64);
     add_simple_struct(&mut module);
     let fun_context = get_fun_context(&module);
@@ -1410,7 +1331,10 @@ fn test_mut_borrow_field_mismatched_types() {
 
 #[test]
 fn test_mut_borrow_field_bad_field() {
-    let code = vec![Bytecode::MutBorrowLoc(0), Bytecode::MutBorrowField(FieldHandleIndex(0))];
+    let code = vec![
+        Bytecode::MutBorrowLoc(0),
+        Bytecode::MutBorrowField(FieldHandleIndex(0)),
+    ];
     let mut module = make_module_with_local(code, SignatureToken::Struct(StructHandleIndex(0)));
     add_native_struct(&mut module);
     let fun_context = get_fun_context(&module);
@@ -1430,7 +1354,6 @@ fn test_mut_borrow_field_no_arg() {
     let fun_context = get_fun_context(&module);
     let _result = type_safety::verify(&module, &fun_context, &mut DummyMeter);
 }
-
 
 #[test]
 fn test_ret_correct_type() {
@@ -1462,10 +1385,13 @@ fn test_ret_no_arg() {
     let _result = type_safety::verify(&module, &fun_context, &mut DummyMeter);
 }
 
-
 #[test]
 fn test_call_correct_types() {
-    let code = vec![Bytecode::LdU64(42), Bytecode::LdTrue, Bytecode::Call(FunctionHandleIndex(1))];
+    let code = vec![
+        Bytecode::LdU64(42),
+        Bytecode::LdTrue,
+        Bytecode::Call(FunctionHandleIndex(1)),
+    ];
     let parameters = Signature(vec![SignatureToken::U64, SignatureToken::Bool]);
     let mut module = make_module(code);
     add_function_with_parameters(&mut module, parameters);
@@ -1476,7 +1402,11 @@ fn test_call_correct_types() {
 
 #[test]
 fn test_call_wrong_types() {
-    let code = vec![Bytecode::LdTrue, Bytecode::LdU64(42), Bytecode::Call(FunctionHandleIndex(1))];
+    let code = vec![
+        Bytecode::LdTrue,
+        Bytecode::LdU64(42),
+        Bytecode::Call(FunctionHandleIndex(1)),
+    ];
     let parameters = Signature(vec![SignatureToken::U64, SignatureToken::Bool]);
     let mut module = make_module(code);
     add_function_with_parameters(&mut module, parameters);

--- a/crates/move-bytecode-verifier/src/type_safety_tests/mod.rs
+++ b/crates/move-bytecode-verifier/src/type_safety_tests/mod.rs
@@ -431,3 +431,34 @@ fn test_or_and_too_few_args() {
         let _result = type_safety::verify(&module, &fun_context, &mut DummyMeter);
     }
 }
+
+
+#[test]
+fn test_not_correct_type() {
+    let code = vec![Bytecode::LdFalse, Bytecode::Not];
+    let module = make_module(code);
+    let fun_context = get_fun_context(&module);
+    let result = type_safety::verify(&module, &fun_context, &mut DummyMeter);
+    assert!(result.is_ok());
+}
+
+#[test]
+fn test_not_wrong_type() {
+    let code = vec![Bytecode::LdU32(42), Bytecode::Not];
+    let module = make_module(code);
+    let fun_context = get_fun_context(&module);
+    let result = type_safety::verify(&module, &fun_context, &mut DummyMeter);
+    assert_eq!(
+        result.unwrap_err().major_status(),
+        StatusCode::BOOLEAN_OP_TYPE_MISMATCH_ERROR
+    );
+}
+
+#[test]
+#[should_panic]
+fn test_not_no_arg() {
+    let code = vec![Bytecode::Not];
+    let module = make_module(code);
+    let fun_context = get_fun_context(&module);
+    let _result = type_safety::verify(&module, &fun_context, &mut DummyMeter);
+}

--- a/crates/move-bytecode-verifier/src/type_safety_tests/mod.rs
+++ b/crates/move-bytecode-verifier/src/type_safety_tests/mod.rs
@@ -998,6 +998,37 @@ fn test_borrow_loc_reference() {
 
 
 #[test]
+fn test_st_lock_correct_type() {
+    let code = vec![Bytecode::LdU32(51), Bytecode::StLoc(0)];
+    let module = make_module_with_local(code, SignatureToken::U32);
+    let fun_context = get_fun_context(&module);
+    let result = type_safety::verify(&module, &fun_context, &mut DummyMeter);
+    assert!(result.is_ok());
+}
+
+#[test]
+fn test_st_lock_mismatched_types() {
+    let code = vec![Bytecode::LdU64(51), Bytecode::StLoc(0)];
+    let module = make_module_with_local(code, SignatureToken::U32);
+    let fun_context = get_fun_context(&module);
+    let result = type_safety::verify(&module, &fun_context, &mut DummyMeter);
+    assert_eq!(
+        result.unwrap_err().major_status(),
+        StatusCode::STLOC_TYPE_MISMATCH_ERROR
+    );
+}
+
+#[test]
+#[should_panic]
+fn test_st_lock_no_arg() {
+    let code = vec![Bytecode::StLoc(0)];
+    let module = make_module_with_local(code, SignatureToken::U32);
+    let fun_context = get_fun_context(&module);
+    let _result = type_safety::verify(&module, &fun_context, &mut DummyMeter);
+}
+
+
+#[test]
 fn test_copy_loc_ok() {
     let code = vec![Bytecode::CopyLoc(0)];
     let module = make_module_with_local(code, SignatureToken::U64);

--- a/crates/move-bytecode-verifier/src/type_safety_tests/mod.rs
+++ b/crates/move-bytecode-verifier/src/type_safety_tests/mod.rs
@@ -594,3 +594,18 @@ fn test_ld_integers_ok() {
     }
 }
 
+
+#[test]
+fn test_ld_true_false_ok() {
+    for instr in vec![
+        Bytecode::LdTrue,
+        Bytecode::LdFalse,
+    ] {
+        let code = vec![instr];
+        let module = make_module(code);
+        let fun_context = get_fun_context(&module);
+        let result = type_safety::verify(&module, &fun_context, &mut DummyMeter);
+        assert!(result.is_ok());
+    }
+}
+

--- a/crates/move-bytecode-verifier/src/type_safety_tests/mod.rs
+++ b/crates/move-bytecode-verifier/src/type_safety_tests/mod.rs
@@ -1,0 +1,77 @@
+use move_binary_format::file_format::{
+    Bytecode, CodeUnit, FunctionDefinition, FunctionHandle,
+    IdentifierIndex, ModuleHandleIndex, SignatureIndex,
+    FunctionDefinitionIndex, empty_module
+};
+
+use move_core_types::vm_status::StatusCode;
+use move_binary_format::CompiledModule;
+use move_bytecode_verifier_meter::dummy::DummyMeter;
+use crate::absint::FunctionContext;
+use crate::type_safety;
+
+
+fn make_module(code: Vec<Bytecode>) -> CompiledModule {
+    let code_unit = CodeUnit {
+        code,
+        ..Default::default()
+    };
+
+    let fun_def = FunctionDefinition {
+        code: Some(code_unit.clone()),
+        ..Default::default()
+    };
+
+    let fun_handle = FunctionHandle {
+        module: ModuleHandleIndex(0),
+        name: IdentifierIndex(0),
+        parameters: SignatureIndex(0),
+        return_: SignatureIndex(0),
+        type_parameters: vec![],
+    };
+
+    let mut module = empty_module();
+    module.function_handles.push(fun_handle);
+    module.function_defs.push(fun_def);
+
+    module
+}
+
+fn get_fun_context(module: &CompiledModule) -> FunctionContext {
+    FunctionContext::new(
+        &module,
+        FunctionDefinitionIndex(0), 
+        module.function_defs[0].code.as_ref().unwrap(),
+        &module.function_handles[0],
+    )
+}
+
+#[test]
+fn test_br_true_bool() {
+    let code = vec![Bytecode::LdTrue, Bytecode::BrTrue(0)];
+    let module = make_module(code);
+    let fun_context = get_fun_context(&module);
+    let result = type_safety::verify(&module, &fun_context, &mut DummyMeter);
+    assert!(result.is_ok());
+}
+
+#[test]
+fn test_br_true_u32() {
+    let code = vec![Bytecode::LdU32(0), Bytecode::BrTrue(0)];
+    let module = make_module(code);
+    let fun_context = get_fun_context(&module);
+    let result = type_safety::verify(&module, &fun_context, &mut DummyMeter);
+    assert_eq!(
+        result.unwrap_err().major_status(),
+        StatusCode::BR_TYPE_MISMATCH_ERROR
+    );
+}
+
+#[test]
+#[should_panic]
+fn test_br_true_no_arg() {
+    let code = vec![Bytecode::BrTrue(0)];
+    let module = make_module(code);
+    let fun_context = get_fun_context(&module);
+    let _result = type_safety::verify(&module, &fun_context, &mut DummyMeter);
+}


### PR DESCRIPTION
This pull request adds tests for `verify_instr` function. Well, actually, not exactly: this pull request adds tests for `verify` function, which calls `verify_instr`. These tests would be used to establish equivalence of this function and its' simulation in Coq.

Progress on tests for instructions:

- [x] `Pop`
- [x] `BrTrue`, `BrFalse`
- [x] `StLoc`
- [x] `Abort`
- [x] `Ret`
- [x] `Branch`, `Nop`
- [x] `FreezeRef`
- [x] `MutBorrowField`
- [x] `ImmBorrowField`
- [x] `MutBorrowFieldGeneric`
- [x] `ImmBorrowFieldGeneric`
- [x] `LdU8`, `LdU16`, `LdU32`, `LdU64`, `LdU128`, `LdU256`
- [x] `LdConst`
- [x] `LdTrue`, `LdFalse`
- [x] `CopyLoc`
- [x] `MoveLoc`
- [x] `MutBorrowLoc`, `ImmBorrowLoc`
- [x] `Call`
- [x] `CallGeneric`
- [x] `Pack`, `Unpack`
- [x] `PackGeneric`, `UnpackGeneric`
- [x] `ReadRef`
- [x] `WriteRef`
- [x] `CastU8`, `CastU16`, `CastU32`, `CastU64`, `CastU128`, `CastU256`
- [x] `Add`, `Sub`, `Mul`, `Mod`, `Div`, `BitOr`, `BitAnd`, `Xor`
- [x] `Shl`, `Shr`
- [x] `Or`, `And`
- [x] `Not`
- [x] `Eq`, `Neq`
- [x] `Lt`, `Gt`, `Le`, `Ge`
- [x] `VecPack`
- [x] `VecLen`
- [x] `VecImmBorrow`
- [x] `VecMutBorrow`
- [x] `VecPushBack`
- [x] `VecPopBack`
- [x] `VecUnpack`
- [x] `VecSwap`

Progress on tests for "deprecated" instructions:
- [x] `ExistsDeprecated`
- [x] `ExistsGenericDeprecated`
- [x] `MoveFromDeprecated`
- [x] `MoveFromGenericDeprecated`
- [x] `MoveToDeprecated`
- [x] `MoveToGenericDeprecated`
- [x] `ImmBorrowGlobalDeprecated`, `MutBorrowGlobalDeprecated`
- [x] `ImmBorrowGlobalGenericDeprecated`, `MutBorrowGlobalGenericDeprecated`